### PR TITLE
ZCS-1206: use  yum --showduplicates instead  --show-duplicate 

### DIFF
--- a/rpmconf/Install/Util/modules/packages.sh
+++ b/rpmconf/Install/Util/modules/packages.sh
@@ -296,7 +296,7 @@ findLatestPackage() {
             file_location="repo"
          fi
       else
-         if grep -q -w -e "^$package" <(yum --show-duplicate list available -q -e 0 "$package" 2>/dev/null)
+         if grep -q -w -e "^$package" <(yum --showduplicates list available -q -e 0 "$package" 2>/dev/null)
          then
             file_location="repo"
          fi


### PR DESCRIPTION
 use  --showduplicates instead  --show-duplicate  which is not working on centOS 6