### PR TITLE
ZCS-1093: Allowing to install chat, drive and suiteplus only if store package is installed

### DIFF
--- a/instructions/FOSS_repo_list.pl
+++ b/instructions/FOSS_repo_list.pl
@@ -37,6 +37,7 @@
    { name => "zm-nginx-lookup-store",                },
    { name => "zm-openid-consumer-store",             },
    { name => "zm-postfix",                           },
+   { name => "zm-pkg-tool",                          },
    { name => "zm-proxy-config-admin-zimlet",         },
    { name => "zm-taglib",                            },
    { name => "zm-timezones",                         },

--- a/instructions/bundling-scripts/zcs-bundle.sh
+++ b/instructions/bundling-scripts/zcs-bundle.sh
@@ -46,6 +46,10 @@ cp -f ${repoDir}/zm-build/rpmconf/Install/install.sh                            
 cp -f ${repoDir}/zm-core-utils/src/libexec/zmdbintegrityreport                          ${ZCS_REL}/bin
 cp -f ${repoDir}/zm-mailbox/store/build/dist/versions-init.sql                          ${ZCS_REL}/data
 cp -f ${repoDir}/zm-build/${arch}/*.*                                                   ${ZCS_REL}/packages
+if [ "${buildType}" = "NETWORK" ]
+then
+   cp -f ${repoDir}/zm-network-zextras/build/dist/*.{deb,rpm}                           ${ZCS_REL}/packages
+fi
 
 chmod 755 ${ZCS_REL}/bin/checkService.pl
 chmod 755 ${ZCS_REL}/bin/checkLicense.pl

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -643,7 +643,7 @@ checkExistingInstall() {
   fi
 
   echo "Checking for existing installation..."
-  
+
   for i in $OPTIONAL_PACKAGES; do
     isInstalled $i
     if [ x$PKGINSTALLED != "x" ]; then
@@ -667,13 +667,6 @@ checkExistingInstall() {
           echo "FOUND zimbra-cms"
           INSTALLED_PACKAGES="$INSTALLED_PACKAGES zimbra-archiving"
         else
-#          echo "NOT FOUND"
-#        fi
-#      elif [ x$i = "xzimbra-syncshare" ]; then
-#        if [ -f "/opt/zimbra/lib/ext/zimbramezeo/zimbramezeo.jar" -a -f "/opt/zimbra/zimlets-network/com_zimbra_zss.zip" ]; then
-#          echo "FOUND zimbra-syncshare"
-#          INSTALLED_PACKAGES="$INSTALLED_PACKAGES zimbra-syncshare"
-#        else
           echo "NOT FOUND"
         fi
       else
@@ -1691,10 +1684,32 @@ removeExistingPackages() {
       continue
     fi
     if [ $p = "zimbra-store" ]; then
+
       isInstalled "zimbra-archiving"
       if [ x$PKGINSTALLED != "x" ]; then
         echo -n "   zimbra-archiving..."
         $PACKAGERM zimbra-archiving >/dev/null 2>&1
+        echo "done"
+      fi
+
+      isInstalled "zimbra-chat"
+      if [ x$PKGINSTALLED != "x" ]; then
+        echo -n "   zimbra-chat..."
+        $PACKAGERM zimbra-chat >/dev/null 2>&1
+        echo "done"
+      fi
+
+      isInstalled "zimbra-drive"
+      if [ x$PKGINSTALLED != "x" ]; then
+        echo -n "   zimbra-drive..."
+        $PACKAGERM zimbra-drive >/dev/null 2>&1
+        echo "done"
+      fi
+
+      isInstalled "zimbra-suiteplus"
+      if [ x$PKGINSTALLED != "x" ]; then
+        echo -n "   zimbra-suiteplus..."
+        $PACKAGERM zimbra-suiteplus >/dev/null 2>&1
         echo "done"
       fi
     fi
@@ -2292,32 +2307,65 @@ getInstallPackages() {
         if [ $STORE_SELECTED = "yes" ]; then
           askYN "Install $i" "N"
         fi
-#      else
-#        askYN "Install $i" "N"
-#      fi
-#      elif [ $i = "zimbra-syncshare" ]; then
-#        if [ $STORE_SELECTED = "yes" ]; then
-#          askYN "Install $i" "N"
-#        fi
       else
         askYN "Install $i" "N"
       fi
-     else
+      if [ $i = "zimbra-chat" ]; then
+        if [ $STORE_SELECTED = "yes" ]; then
+          askYN "Install $i" "N"
+        fi
+      else
+        askYN "Install $i" "N"
+      fi
+      if [ $i = "zimbra-drive" ]; then
+        if [ $STORE_SELECTED = "yes" ]; then
+          askYN "Install $i" "N"
+        fi
+      else
+        askYN "Install $i" "N"
+      fi
+      if [ $i = "zimbra-suiteplus" ]; then
+        if [ $STORE_SELECTED = "yes" ]; then
+          askYN "Install $i" "N"
+        fi
+      else
+        askYN "Install $i" "N"
+      fi
+    else
       if [ $i = "zimbra-archiving" ]; then
         # only prompt to install archiving if zimbra-store is selected
         if [ $STORE_SELECTED = "yes" ]; then
           askYN "Install $i" "N"
         fi
-#      elif [ $i = "zimbra-syncshare" ]; then
-#        if [ $STORE_SELECTED = "yes" ]; then
-#          askYN "Install $i" "N"
-#        fi
+
       elif [ $i = "zimbra-convertd" ]; then
         if [ $STORE_SELECTED = "yes" ]; then
           askYN "Install $i" "Y"
         else
           askYN "Install $i" "N"
         fi
+
+      elif [ $i = "zimbra-chat" ]; then
+        if [ $STORE_SELECTED = "yes" ]; then
+          askYN "Install $i" "Y"
+        else
+          askYN "Install $i" "N"
+        fi
+
+      elif [ $i = "zimbra-drive" ]; then
+        if [ $STORE_SELECTED = "yes" ]; then
+          askYN "Install $i" "Y"
+        else
+          askYN "Install $i" "N"
+        fi
+
+      elif [ $i = "zimbra-suiteplus" ]; then
+        if [ $STORE_SELECTED = "yes" ]; then
+          askYN "Install $i" "Y"
+        else
+          askYN "Install $i" "N"
+        fi
+
       elif [ $i = "zimbra-dnscache" ]; then
         if [ $MTA_SELECTED = "yes" ]; then
           askYN "Install $i" "Y"


### PR DESCRIPTION
ZCS-1093: Allowing to install chat, drive and suiteplus only if store package is installed

- Added code for zimbra chat, drive and suiteplus
- Removed syncshare
