### PR TITLE
ZCS-1290: removing chat/drive/zsp option when store is not installed

### DIFF
--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -2346,22 +2346,16 @@ getInstallPackages() {
       elif [ $i = "zimbra-chat" ]; then
         if [ $STORE_SELECTED = "yes" ]; then
           askYN "Install $i" "Y"
-        else
-          askYN "Install $i" "N"
         fi
 
       elif [ $i = "zimbra-drive" ]; then
         if [ $STORE_SELECTED = "yes" ]; then
           askYN "Install $i" "Y"
-        else
-          askYN "Install $i" "N"
         fi
 
       elif [ $i = "zimbra-suiteplus" ]; then
         if [ $STORE_SELECTED = "yes" ]; then
           askYN "Install $i" "Y"
-        else
-          askYN "Install $i" "N"
         fi
 
       elif [ $i = "zimbra-dnscache" ]; then


### PR DESCRIPTION
removing chat/drive/zsp option when store is not installed