### PR TITLE
feature/zms-38 updates

### DIFF
--- a/instructions/FOSS_package_list.pl
+++ b/instructions/FOSS_package_list.pl
@@ -9,4 +9,5 @@
    "zimbra-apache",
    "zimbra-spell",
    "zimbra-proxy",
+   "zimbra-imapd",
 );

--- a/instructions/bundling-scripts/zimbra-imapd.sh
+++ b/instructions/bundling-scripts/zimbra-imapd.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Server
+# Copyright (C) 2017 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.  # You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+
+# Shell script to create zimbra-imapd package
+
+
+#-------------------- Configuration ---------------------------
+
+    currentScript=`basename $0 | cut -d "." -f 1`                          # zimbra-imapd
+    currentPackage=`echo ${currentScript}build | cut -d "-" -f 2`          # imapbuild
+
+
+#-------------------- Build Package ---------------------------
+main()
+{
+    echo -e "\tCreate package directories" >> ${buildLogFile}
+    mkdir -p ${repoDir}/zm-build/${currentPackage}/opt/zimbra/bin
+    mkdir -p ${repoDir}/zm-build/${currentPackage}/opt/zimbra/conf
+    mkdir -p ${repoDir}/zm-build/${currentPackage}/opt/zimbra/lib/jars
+
+
+    echo -e "\tCopy package files" >> ${buildLogFile}
+    cp ${repoDir}/zm-core-utils/src/bin/zmimapdctl ${repoDir}/zm-build/${currentPackage}/opt/zimbra/bin/zmimapdctl
+    cp ${repoDir}/zm-zcs-lib/build/dist/oauth-1.4.jar ${repoDir}/zm-build/${currentPackage}/opt/zimbra/lib/jars/oauth-1.4.jar
+    cp ${repoDir}/zm-mailbox/store-conf/conf/imapd.log4j.properties ${repoDir}/zm-build/${currentPackage}/opt/zimbra/conf/imapd.log4j.properties
+    CreatePackage "${os}"
+}
+
+#-------------------- Util Functions ---------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+source "$SCRIPT_DIR/utils.sh"
+
+CreateDebianPackage()
+{
+    mkdir -p ${repoDir}/zm-build/${currentPackage}/DEBIAN
+    cat ${repoDir}/zm-build/rpmconf/Spec/Scripts/${currentScript}.post >> ${repoDir}/zm-build/${currentPackage}/DEBIAN/postinst
+    chmod 555 ${repoDir}/zm-build/${currentPackage}/DEBIAN/*
+
+    echo -e "\tCreate debian package" >> ${buildLogFile}
+    (cd ${repoDir}/zm-build/${currentPackage}; find . -type f ! -regex '.*?debian-binary.*' ! -regex '.*?DEBIAN.*' -print0 | xargs -0 md5sum | sed -e 's| \./| |' \
+        > ${repoDir}/zm-build/${currentPackage}/DEBIAN/md5sums)
+    cat ${repoDir}/zm-build/rpmconf/Spec/${currentScript}.deb | sed -e "s/@@VERSION@@/${releaseNo}.${releaseCandidate}.${buildNo}.${os/_/.}/" -e "s/@@branch@@/${buildTimeStamp}/" -e "s/@@ARCH@@/${arch}/" \
+        > ${repoDir}/zm-build/${currentPackage}/DEBIAN/control
+    (cd ${repoDir}/zm-build/${currentPackage}; dpkg -b ${repoDir}/zm-build/${currentPackage} ${repoDir}/zm-build/${arch})
+
+}
+
+CreateRhelPackage()
+{
+    cat ${repoDir}/zm-build/rpmconf/Spec/${currentScript}.spec | \
+        sed -e "s/@@VERSION@@/${releaseNo}_${releaseCandidate}_${buildNo}.${os}/" \
+        -e "s/@@RELEASE@@/${buildTimeStamp}/" \
+        -e "s/^Copyright:/Copyright:/" \
+        > ${repoDir}/zm-build/${currentScript}.spec
+    echo "%attr(-, root, root) /opt/zimbra/bin/zmimapdctl" >> \
+        ${repoDir}/zm-build/${currentScript}.spec
+    echo "%attr(-, root, root) /opt/zimbra/lib/jars/oauth-1.4.jar" >> \
+        ${repoDir}/zm-build/${currentScript}.spec
+    echo "%attr(755, zimbra, zimbra) /opt/zimbra/conf/imapd.log4j.properties" >> \
+        ${repoDir}/zm-build/${currentScript}.spec
+    echo "" >> ${repoDir}/zm-build/${currentScript}.spec
+    echo "%clean" >> ${repoDir}/zm-build/${currentScript}.spec
+    (cd ${repoDir}/zm-build/${currentPackage}; \
+        rpmbuild --target ${arch} --define '_rpmdir ../' --buildroot=${repoDir}/zm-build/${currentPackage} -bb ${repoDir}/zm-build/${currentScript}.spec )
+}
+
+############################################################################
+main "$@"

--- a/rpmconf/Install/Util/globals.sh
+++ b/rpmconf/Install/Util/globals.sh
@@ -39,7 +39,8 @@ SERVICES=""
 OPTIONAL_PACKAGES="zimbra-qatest \
 zimbra-chat \
 zimbra-drive \
-zimbra-suiteplus"
+zimbra-suiteplus \
+zimbra-imapd"
 
 PACKAGE_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)/packages"
 

--- a/rpmconf/Spec/zimbra-imapd.deb
+++ b/rpmconf/Spec/zimbra-imapd.deb
@@ -1,0 +1,8 @@
+Package: zimbra-imapd
+Version: @@VERSION@@
+Description: Best email money can buy
+Maintainer: build@zimbra.com
+Section: Mail
+Priority: optional
+Architecture: @@ARCH@@
+Depends: zimbra-core

--- a/rpmconf/Spec/zimbra-imapd.spec
+++ b/rpmconf/Spec/zimbra-imapd.spec
@@ -1,0 +1,36 @@
+#
+# spec file for zimbra-imapd.rpm
+#
+Summary: Zimbra IMAP
+Name: zimbra-imapd
+Version: @@VERSION@@
+Release: @@RELEASE@@
+License: Various
+Group: Applications/Messaging
+URL: http://www.zimbra.com
+Vendor: Zimbra, Inc.
+Packager: Zimbra, Inc.
+BuildRoot: /opt/zimbra
+AutoReqProv: no
+requires: zimbra-core
+
+%description
+Best email money can buy
+
+%define __spec_install_pre /bin/true
+
+%prep
+
+%build
+
+%install
+
+%pre
+
+%post
+
+%preun
+
+%postun
+
+%files


### PR DESCRIPTION
## zm-build

### packaging

The following packaging-related updates were made:

* `instructions/bundling-scripts/zimbra-imap.sh`
* `rpmconf/Spec/zimbra-imap.deb`
* `rpmconf/Spec/zimbra-imap.spec`
* `instructions/FOSS_package_list.pl`

### building an installer

Please note that there are several commits that will be rebased out that are related to the `instructions/FOSS_repo_list.pl` file.  They allow a build to be created based on the various `feature/zms-38` branches.  Once all pull requests have been merged, the repo list will be updated accordingly.

### configuration

`zmsetup.pl` has been updated to support the new _zimbra-imap_ service.

* Invoke the newly-updated `zmcertmgr` to create the `keystore` needed by _zimbra-imap_
* Allow selection of the new _zimbra-imap_ service as an optional install.

		...
		Install zimbra-proxy [Y] N
		Install zimbra-chat [Y] N
		Install zimbra-drive [Y] N
		Install zimbra-imap [Y] Y
	
* Provide a new menu that allows the user to determine if the installer should automatically configure the _zimbra-imap_ service.

		...
		5) zimbra-spell:                            Enabled
		6) zimbra-proxy:                            Enabled
		7) zimbra-imap:                             Enabled
		...
		
	and


		IMAP configuration

		1) Status:                                  Enabled
		2) Add to upstream IMAP Servers?:           yes


Please also see related pull requests for:

* `zm-zcs-lib`
* `zm-nginx-lookup-store`
* `zm-mailbox`
* `zm-core-utils`
