### PR TITLE
ZCS-1373:need zm-core-utils for zmlocalconfig

### DIFF
--- a/instructions/FOSS_repo_list.pl
+++ b/instructions/FOSS_repo_list.pl
@@ -17,7 +17,7 @@
    { name => "zm-clam-scanner-store",                },
    { name => "zm-clientuploader-admin-zimlet",       },
    { name => "zm-clientuploader-store",              },
-   { name => "zm-core-utils",                        },
+   { name => "zm-core-utils",                       branch => "feature/imap", },
    { name => "zm-db-conf",                           },
    { name => "zm-dnscache",                          },
    { name => "zm-downloads",                         },


### PR DESCRIPTION
`zmlocalconfig` has changed in **zm-core-utils** on the feature/imap
branch.