### PR TITLE
ZCS-1350: Add ZCO and Migration binaries in builds

### DIFF
--- a/instructions/bundling-scripts/zimbra-store.sh
+++ b/instructions/bundling-scripts/zimbra-store.sh
@@ -180,8 +180,26 @@ main()
     cp -rf ${repoDir}/zm-webclient-portal-example/example ${repoDir}/zm-build/${currentPackage}/opt/zimbra/${jettyVersion}/webapps/zimbra/portals
 
     echo "\t\t***** downloads content *****" >> ${buildLogFile}
-    mkdir -p ${repoDir}/zm-build/${currentPackage}/opt/zimbra/${jettyVersion}/webapps/zimbra/downloads
-    cp -rf ${repoDir}/zm-downloads/. ${repoDir}/zm-build/${currentPackage}/opt/zimbra/${jettyVersion}/webapps/zimbra/downloads
+    downloadsDir=${repoDir}/zm-build/${currentPackage}/opt/zimbra/${jettyVersion}/webapps/zimbra/downloads
+    mkdir -p ${downloadsDir}
+    cp -rf ${repoDir}/zm-downloads/. ${downloadsDir}
+
+    if [ "${buildType}" == "NETWORK" ]
+    then
+      scp -r root@${zimbraThirdPartyServer}:/ZimbraThirdParty/zco-migration-builds/current/* ${downloadsDir}
+      cd ${downloadsDir}
+
+      zcoMigrationBuilds=("ZimbraConnectorOLK_*_x64.msi" \
+          "ZimbraConnectorOLK_*_x64-UNSIGNED.msi" \
+          "ZimbraConnectorOLK_*_x86.msi" \
+          "ZimbraConnectorOLK_*_x86-UNSIGNED.msi" \
+          "ZimbraMigration_*_x64.zip" \
+          "ZimbraMigration_*_x86.zip" \
+          "ZCSPSTImportWizard-*.zip" \
+          "ZCSDominoMigrationWizard-*.zip \
+          "ZCSGroupwiseMigrationWizard-*.zip \
+          "ZCSExchangeMigrationWizard-*.zip");
+    fi
 
     echo "\t\t***** robots.txt content *****" >> ${buildLogFile}
     cp -rf ${repoDir}/zm-aspell/conf/robots.txt ${repoDir}/zm-build/${currentPackage}/opt/zimbra/${jettyVersion}/webapps/zimbra
@@ -190,6 +208,53 @@ main()
     echo "\t\t++++++++++ zimbraAdmin.war content ++++++++++" >> ${buildLogFile}
     mkdir -p ${repoDir}/zm-build/${currentPackage}/opt/zimbra/${jettyVersion}/webapps/zimbraAdmin
     cd ${repoDir}/zm-build/${currentPackage}/opt/zimbra/${jettyVersion}/webapps/zimbraAdmin; jar -xf ${repoDir}/zm-admin-console/build/dist/jetty/webapps/zimbraAdmin.war
+
+    zaMsgPropertiesFile="${repoDir}/zm-build/${currentPackage}/opt/zimbra/${jettyVersion}/webapps/zimbraAdmin/WEB-INF/classes/messages/ZaMsg.properties"
+
+    if [ "${buildType}" == "NETWORK" ]
+    then
+      cd ${downloadsDir}
+
+      # ZimbraConnectorOLK_*_x64.msi
+      download=`ls ZimbraConnectorOLK_*_x64.msi`
+      echo "CONNECTOR_64_DOWNLOAD_LINK = /downloads/${download}" >> ${zaMsgPropertiesFile}; \
+
+      # ZimbraConnectorOLK_*_x64-UNSIGNED.msi
+      download=`ls ZimbraConnectorOLK_*_x64-UNSIGNED.msi`
+      echo "CONNECTOR_UNSIGNED_64_DOWNLOAD_LINK = /downloads/${download}" >> ${zaMsgPropertiesFile}; \
+
+      # ZimbraConnectorOLK_*_x86.msi
+      download=`ls ZimbraConnectorOLK_*_x86.msi`
+      echo "CONNECTOR_32_DOWNLOAD_LINK = /downloads/${download}" >> ${zaMsgPropertiesFile}; \
+
+      # ZimbraConnectorOLK_*_x86-UNSIGNED.msi
+      download=`ls ZimbraConnectorOLK_*_x86-UNSIGNED.msi`
+      echo "CONNECTOR_UNSIGNED_32_DOWNLOAD_LINK = /downloads/${download}" >> ${zaMsgPropertiesFile}; \
+
+      # ZimbraMigration_*_x64.zip
+      download=`ls ZimbraMigration_*_x64.zip`
+      echo "GENERAL_MIG_WIZ_X64_DOWNLOAD_LINK = /downloads/${download}" >> ${zaMsgPropertiesFile}; \
+
+      # ZimbraMigration_*_x86.zip
+      download=`ls ZimbraMigration_*_x86.zip`
+      echo "GENERAL_MIG_WIZ_X86_DOWNLOAD_LINK = /downloads/${download}" >> ${zaMsgPropertiesFile}; \
+
+      # ZCSPSTImportWizard-*.zip
+      download=`ls ZCSPSTImportWizard-*.zip`
+      echo "IMPORT_WIZ_DOWNLOAD_LINK = /downloads/${download}" >> ${zaMsgPropertiesFile}; \
+
+      # ZCSDominoMigrationWizard-*.zip
+      download=`ls ZCSDominoMigrationWizard-*.zip`
+      echo "DOMINO_MIG_WIZ_DOWNLOAD_LINK = /downloads/${download}" >> ${zaMsgPropertiesFile}; \
+
+      # ZCSGroupwiseMigrationWizard-*.zip
+      download=`ls ZCSGroupwiseMigrationWizard-*.zip`
+      echo "GROUPWISE_MIG_WIZ_DOWNLOAD_LINK = /downloads/${download}" >> ${zaMsgPropertiesFile}; \
+
+      # ZCSExchangeMigrationWizard-*.zip
+      download=`ls ZCSExchangeMigrationWizard-*.zip`
+      echo "MIG_WIZ_DOWNLOAD_LINK = /downloads/${download}" >> ${zaMsgPropertiesFile}; \
+    fi
 
     echo "\t\t***** help content *****" >> ${buildLogFile}
     rsync -a ${repoDir}/zm-admin-help-common/WebRoot/help ${repoDir}/zm-build/${currentPackage}/opt/zimbra/${jettyVersion}/webapps/zimbraAdmin/


### PR DESCRIPTION
ZCS-1350: Add ZCO and Migration binaries in builds

Integrated and tested all ZCO and Migration binaries in build, zimbra web client and admin console. Sample screenshots:

![migration](https://cloud.githubusercontent.com/assets/21263826/26028436/f058ac06-383d-11e7-87ad-950e121098ba.png)
![zco](https://cloud.githubusercontent.com/assets/21263826/26028438/f5e0b484-383d-11e7-87bd-dd1011fb5954.png)
