### PR TITLE
Bug 107976 execute mysql_upgrade for 8.8

### DIFF
--- a/rpmconf/Upgrade/zmupgrade.pm
+++ b/rpmconf/Upgrade/zmupgrade.pm
@@ -130,6 +130,8 @@ my %updateMysql = (
 my %setNeedMysqlUpgrade = (
   "8.0.0_GA" => 1,
   "8.5.0_BETA1" => 1,
+  # Bug #107976
+  "8.8.0_BETA1" => 1,
 );
 
 sub version_cmp($$)
@@ -260,7 +262,7 @@ sub upgrade {
 
     if (@{applicableVersions(\%setNeedMysqlUpgrade)}) {
       $needMysqlUpgrade=1;
-   } 
+    }
   }
 
   main::setLocalConfig("ssl_allow_untrusted_certs", "true") if ($startMajor <= 7 && $targetMajor >= 8);


### PR DESCRIPTION
This step was missed for the 8.7.0 release so add it to the next 8.7.x update to be released.

I didn't test this, just added the obvious piece of code. Well, relatively obvious, I chose the `$targetVersion` as the trigger, maybe the `$sourceVersion` is preferred? Should have the same effect. Somebody please do the QA on this.