### PR TITLE
ZCS-1350: Add ZCO and Migration binaries in builds

### DIFF
--- a/instructions/bundling-scripts/zimbra-store.sh
+++ b/instructions/bundling-scripts/zimbra-store.sh
@@ -180,16 +180,80 @@ main()
     cp -rf ${repoDir}/zm-webclient-portal-example/example ${repoDir}/zm-build/${currentPackage}/opt/zimbra/${jettyVersion}/webapps/zimbra/portals
 
     echo "\t\t***** downloads content *****" >> ${buildLogFile}
-    mkdir -p ${repoDir}/zm-build/${currentPackage}/opt/zimbra/${jettyVersion}/webapps/zimbra/downloads
-    cp -rf ${repoDir}/zm-downloads/. ${repoDir}/zm-build/${currentPackage}/opt/zimbra/${jettyVersion}/webapps/zimbra/downloads
+    downloadsDir=${repoDir}/zm-build/${currentPackage}/opt/zimbra/${jettyVersion}/webapps/zimbra/downloads
+    mkdir -p ${downloadsDir}
+    cp -rf ${repoDir}/zm-downloads/. ${downloadsDir}
+
+    if [ "${buildType}" == "NETWORK" ]
+    then
+      scp -r root@${zimbraThirdPartyServer}:/ZimbraThirdParty/zco-migration-builds/current/* ${downloadsDir}
+      cd ${downloadsDir}
+
+      zcoMigrationBuilds=("ZimbraConnectorOLK_*_x64.msi" \
+          "ZimbraConnectorOLK_*_x64-UNSIGNED.msi" \
+          "ZimbraConnectorOLK_*_x86.msi" \
+          "ZimbraConnectorOLK_*_x86-UNSIGNED.msi" \
+          "ZimbraMigration_*_x64.zip" \
+          "ZimbraMigration_*_x86.zip" \
+          "ZCSPSTImportWizard-*.zip" \
+          "ZCSDominoMigrationWizard-*.zip \
+          "ZCSGroupwiseMigrationWizard-*.exe \
+          "ZCSExchangeMigrationWizard-*.zip");
+    fi
 
     echo "\t\t***** robots.txt content *****" >> ${buildLogFile}
     cp -rf ${repoDir}/zm-aspell/conf/robots.txt ${repoDir}/zm-build/${currentPackage}/opt/zimbra/${jettyVersion}/webapps/zimbra
 
-
     echo "\t\t++++++++++ zimbraAdmin.war content ++++++++++" >> ${buildLogFile}
     mkdir -p ${repoDir}/zm-build/${currentPackage}/opt/zimbra/${jettyVersion}/webapps/zimbraAdmin
     cd ${repoDir}/zm-build/${currentPackage}/opt/zimbra/${jettyVersion}/webapps/zimbraAdmin; jar -xf ${repoDir}/zm-admin-console/build/dist/jetty/webapps/zimbraAdmin.war
+
+    zaMsgPropertiesFile="${repoDir}/zm-build/${currentPackage}/opt/zimbra/${jettyVersion}/webapps/zimbraAdmin/WEB-INF/classes/messages/ZaMsg.properties"
+
+    if [ "${buildType}" == "NETWORK" ]
+    then
+      cd ${downloadsDir}
+
+      # ZimbraConnectorOLK_*_x64.msi
+      download=`ls ZimbraConnectorOLK_*_x64.msi`
+      echo "CONNECTOR_64_DOWNLOAD_LINK = /downloads/${download}" >> ${zaMsgPropertiesFile}; \
+
+      # ZimbraConnectorOLK_*_x64-UNSIGNED.msi
+      download=`ls ZimbraConnectorOLK_*_x64-UNSIGNED.msi`
+      echo "CONNECTOR_UNSIGNED_64_DOWNLOAD_LINK = /downloads/${download}" >> ${zaMsgPropertiesFile}; \
+
+      # ZimbraConnectorOLK_*_x86.msi
+      download=`ls ZimbraConnectorOLK_*_x86.msi`
+      echo "CONNECTOR_32_DOWNLOAD_LINK = /downloads/${download}" >> ${zaMsgPropertiesFile}; \
+
+      # ZimbraConnectorOLK_*_x86-UNSIGNED.msi
+      download=`ls ZimbraConnectorOLK_*_x86-UNSIGNED.msi`
+      echo "CONNECTOR_UNSIGNED_32_DOWNLOAD_LINK = /downloads/${download}" >> ${zaMsgPropertiesFile}; \
+
+      # ZimbraMigration_*_x64.zip
+      download=`ls ZimbraMigration_*_x64.zip`
+      echo "GENERAL_MIG_WIZ_X64_DOWNLOAD_LINK = /downloads/${download}" >> ${zaMsgPropertiesFile}; \
+
+      # ZimbraMigration_*_x86.zip
+      download=`ls ZimbraMigration_*_x86.zip`
+      echo "GENERAL_MIG_WIZ_X86_DOWNLOAD_LINK = /downloads/${download}" >> ${zaMsgPropertiesFile}; \
+
+      # ZCSPSTImportWizard-*.zip
+      download=`ls ZCSPSTImportWizard-*.zip`
+      echo "IMPORT_WIZ_DOWNLOAD_LINK = /downloads/${download}" >> ${zaMsgPropertiesFile}; \
+
+      # ZCSDominoMigrationWizard-*.zip
+      download=`ls ZCSDominoMigrationWizard-*.zip`
+      echo "DOMINO_MIG_WIZ_DOWNLOAD_LINK = /downloads/${download}" >> ${zaMsgPropertiesFile}; \
+
+      # ZCSGroupwiseMigrationWizard-*.exe
+      download=`ls ZCSGroupwiseMigrationWizard-*.exe`
+      echo "GROUPWISE_MIG_WIZ_DOWNLOAD_LINK = /downloads/${download}" >> ${zaMsgPropertiesFile}; \
+
+      # ZCSExchangeMigrationWizard-*.zip
+      download=`ls ZCSExchangeMigrationWizard-*.zip`
+      echo "MIG_WIZ_DOWNLOAD_LINK = /downloads/${download}" >> ${zaMsgPropertiesFile}; \
+    fi
 
     echo "\t\t***** help content *****" >> ${buildLogFile}
     rsync -a ${repoDir}/zm-admin-help-common/WebRoot/help ${repoDir}/zm-build/${currentPackage}/opt/zimbra/${jettyVersion}/webapps/zimbraAdmin/

--- a/instructions/bundling-scripts/zimbra-store.sh
+++ b/instructions/bundling-scripts/zimbra-store.sh
@@ -189,7 +189,9 @@ main()
       scp -r root@${zimbraThirdPartyServer}:/ZimbraThirdParty/zco-migration-builds/current/* ${downloadsDir}
       cd ${downloadsDir}
 
-      zcoMigrationBuilds=("ZimbraConnectorOLK_*_x64.msi" \
+      zcoMigrationBuilds=("ZmCustomizeMsi.js" \
+          "ZimbraBrandMsi.vbs" \
+          "ZimbraConnectorOLK_*_x64.msi" \
           "ZimbraConnectorOLK_*_x64-UNSIGNED.msi" \
           "ZimbraConnectorOLK_*_x86.msi" \
           "ZimbraConnectorOLK_*_x86-UNSIGNED.msi" \
@@ -213,6 +215,14 @@ main()
     if [ "${buildType}" == "NETWORK" ]
     then
       cd ${downloadsDir}
+
+      # ZmCustomizeMsi.js
+      download=`ls ZmCustomizeMsi.js`
+      echo "CONNECTOR_MSI_DOWNLOAD_LINK = /downloads/${download}" >> ${zaMsgPropertiesFile}; \
+      
+      # ZimbraBrandMsi.vbs
+      download=`ls ZimbraBrandMsi.vbs`
+      echo "ZCO_BRANDING_DOWNLOAD_LINK = /downloads/${download}" >> ${zaMsgPropertiesFile}; \
 
       # ZimbraConnectorOLK_*_x64.msi
       download=`ls ZimbraConnectorOLK_*_x64.msi`


### PR DESCRIPTION
ZCS-1350: Add ZCO and Migration binaries in builds

- Included ZCO and Migration binaries in the build
- Tested /opt/zimbra/jetty-distribution-9.3.5.v20151012/webapps/zimbra/downloads contents
- Tested all the links of https://<server>/downloads/index.html
- Tested all the links of https://<server>:7071/zimbraAdmin/ -> Tools & Migration -> Download links.

![jetty downloads content](https://cloud.githubusercontent.com/assets/21263826/26410583/5cc3fbd0-40c1-11e7-9b91-9c181759fdb3.png)
![migration download works](https://cloud.githubusercontent.com/assets/21263826/26410584/5dc3277c-40c1-11e7-9b67-d5b839cc9b73.png)
![pst download works from admin console](https://cloud.githubusercontent.com/assets/21263826/26410595/67c507c2-40c1-11e7-9d9b-fd7ef6839e04.png)
![zco download works](https://cloud.githubusercontent.com/assets/21263826/26410604/6d1a6866-40c1-11e7-969e-475e41c3ab24.png)

