### PR TITLE
ZCS-1480 Change default imapd config option

### DIFF
--- a/rpmconf/Install/zmsetup.pl
+++ b/rpmconf/Install/zmsetup.pl
@@ -1579,7 +1579,7 @@ sub setDefaults {
 
   if (isEnabled("zimbra-imapd")) {
     progress  "setting defaults for zimbra-imapd.\n" if $options{d};
-    $config{DOADDUPSTREAMIMAP} = "yes";
+    $config{DOADDUPSTREAMIMAP} = "no";
   }
 
   $config{zimbra_require_interprocess_security} = 1;


### PR DESCRIPTION
Change to default behavior of the `IMAPD Configuration` config
section to *not* enable the `Add to upstream IMAP Servers?` by default.

NOTE: For proper operation after installation to occur, this PR assumes that the work for ZCS-1494 has been merged.