### PR TITLE
ZCS-1443 Fix zimbra-imapd build

### DIFF
--- a/instructions/FOSS_staging_list.pl
+++ b/instructions/FOSS_staging_list.pl
@@ -4,6 +4,8 @@
       "ant_targets"     => [ "all", "pkg" ],
       "deploy_pkg_into" => "bundle",
       "stage_cmd"       => sub {
+         System("mkdir -p                                 $GLOBAL_BUILD_DIR/zm-mailbox/store-conf/");
+         System("rsync -az store-conf/conf                $GLOBAL_BUILD_DIR/zm-mailbox/store-conf/");
          System("install -T -D store/build/dist/versions-init.sql $GLOBAL_BUILD_DIR/zm-mailbox/store/build/dist/versions-init.sql");
       },
    },


### PR DESCRIPTION
Some of the build changes made on develop broke the zimbra-imapd build.
Had to update FOSS_staging_list so that the store-conf directory
gets properly staged.