### PR TITLE
allow source for builds to come from github.com/f9teams/*

### DIFF
--- a/instructions/FOSS_remote_list.pl
+++ b/instructions/FOSS_remote_list.pl
@@ -1,4 +1,5 @@
 @ENTRIES = (
    "gh-zm" => { 'url-prefix' => "https://github.com/Zimbra", },
    "gh-ks" => { 'url-prefix' => "https://github.com/kohlschutter", },
+   "gh-f9" => { 'url-prefix' => "https://github.com/f9teams", },
 );


### PR DESCRIPTION
add a remote named `gh-f9` that allows specific repositories to be pulled from the `f9teams` GitHub organization.

Related to https://github.com/f9teams/zm-docker/commit/27629b28c246b8ca5274695908500d4069b64023#diff-56314e392940cd06bb30fd2cba7fd70fR14