### PR TITLE
ZCS-1661 Move zm-timezone compilation step ahead of zm-web-client and zm-admin-console

### DIFF
--- a/instructions/FOSS_staging_list.pl
+++ b/instructions/FOSS_staging_list.pl
@@ -18,6 +18,13 @@
       "deploy_pkg_into" => "repo-dev",
    },
    {
+      "dir"         => "zm-timezones",
+      "ant_targets" => ["publish-local"],
+      "stage_cmd"   => sub {
+         System("(cd .. && rsync -az --relative zm-timezones $GLOBAL_BUILD_DIR/)");
+      },
+   },
+   {
       "dir"         => "junixsocket/junixsocket-native",
       "mvn_targets" => ["package"],
       "stage_cmd"   => sub {
@@ -375,13 +382,6 @@
       "ant_targets" => undef,
       "stage_cmd"   => sub {
          System("cp -f -r ../zm-jetty-conf $GLOBAL_BUILD_DIR");
-      },
-   },
-   {
-      "dir"         => "zm-timezones",
-      "ant_targets" => undef,
-      "stage_cmd"   => sub {
-         System("(cd .. && rsync -az --relative zm-timezones $GLOBAL_BUILD_DIR/)");
       },
    },
 );


### PR DESCRIPTION
FOSS_staging_list.pl
   - add publish-local target for zm-timezones
   - move it up in the order to make sure it is compiled first before zm-web-client and zm-admin-console