### PR TITLE
ZCS-1877 Fixing ews stub version in bundling script

### DIFF
--- a/instructions/bundling-scripts/zimbra-core.sh
+++ b/instructions/bundling-scripts/zimbra-core.sh
@@ -701,7 +701,7 @@ main()
       "yuicompressor-2.4.2-zimbra.jar"
       "zkclient-0.1.0.jar"
       "zookeeper-3.4.5.jar"
-      "zm-ews-stub-1.0.jar"
+      "zm-ews-stub-2.0.jar"
       "ehcache-3.1.2.jar"
    )
 


### PR DESCRIPTION
Fixing ews stub version zimbra-core.sh which installs it in /opt/zimbra/lib/jars