### PR TITLE
ZCS-1902: Disable attribute "zimbraNetworkMobileNGEnabled" when "zimbra-network-modules-ng" is not installed.

### DIFF
--- a/rpmconf/Install/zmsetup.pl
+++ b/rpmconf/Install/zmsetup.pl
@@ -7030,6 +7030,11 @@ sub applyConfig {
       }
     }
 
+    if (!isInstalled("zimbra-network-modules-ng")) {
+      main::progress("Disabling zimbraNetworkModulesNGEnabled \n");
+      setLdapServerConfig($config{HOSTNAME}, 'zimbraNetworkModulesNGEnabled', 'FALSE');
+    }
+
     if (!isInstalled("zimbra-network-modules-ng") || (!$newinstall && prevVersionBelow880())) {
       main::progress("Disabling zimbraNetworkMobileNGEnabled \n");
       setLdapServerConfig($config{HOSTNAME}, 'zimbraNetworkMobileNGEnabled', 'FALSE');


### PR DESCRIPTION
Disabled attribute "zimbraNetworkMobileNGEnabled" when "zimbra-network-modules-ng" is not installed.