### PR TITLE
ZCS-1790: Build zm-ssdb-ephemeral-store from feature/imap

### DIFF
--- a/instructions/FOSS_repo_list.pl
+++ b/instructions/FOSS_repo_list.pl
@@ -39,7 +39,7 @@
    { name => "zm-pkg-tool",                          },
    { name => "zm-postfix",                           },
    { name => "zm-proxy-config-admin-zimlet",         },
-   { name => "zm-ssdb-ephemeral-store",              },
+   { name => "zm-ssdb-ephemeral-store",             branch => "feature/imap", },
    { name => "zm-taglib",                            },
    { name => "zm-timezones",                         },
    { name => "zm-versioncheck-admin-zimlet",         },


### PR DESCRIPTION
ZCS-1790 involved a change to the zm-ssdb-ephemeral-store repo, so we have to re-introduce a feature/imap branch again.