### PR TITLE
ZCS-1955: Update build scripts to use zm-admin-ajax instead of zm-ajax for admin console.

### DIFF
--- a/instructions/FOSS_repo_list.pl
+++ b/instructions/FOSS_repo_list.pl
@@ -7,6 +7,7 @@
    { name => "zm-admin-console",                     },
    { name => "zm-admin-help-common",                 },
    { name => "zm-ajax",                              },
+   { name => "zm-admin-ajax",                        },
    { name => "zm-amavis",                            },
    { name => "zm-aspell",                            },
    { name => "zm-bulkprovision-admin-zimlet",        },

--- a/instructions/FOSS_staging_list.pl
+++ b/instructions/FOSS_staging_list.pl
@@ -62,6 +62,11 @@
       "stage_cmd"   => undef,
    },
    {
+      "dir"         => "zm-admin-ajax",
+      "ant_targets" => ["publish-local"],
+      "stage_cmd"   => undef,
+   },
+   {
       "dir"         => "zm-ssdb-ephemeral-store",
       "ant_targets" => ["publish-local"],
       "stage_cmd"   => sub {


### PR DESCRIPTION
ZCS-1955: Update build scripts to use zm-admin-ajax instead of zm-ajax for admin console.

Changeset:
 * FOSS_repo_list.pl: Adding entry for zm-admin-ajax repository.
 * FOSS_staging_list.pl: Adding entry for zm-admin-ajax repository with ant targets to be called for getting the artifacts required by zm-admin-console.