### PR TITLE
ZCS-2491 Fix non-interactive configure with new install

### DIFF
--- a/rpmconf/Install/zmsetup.pl
+++ b/rpmconf/Install/zmsetup.pl
@@ -199,6 +199,9 @@ if (! $newinstall ) {
   }
 
   # if we're an upgrade, run the upgrader...
+  if ($prevVersion eq "") {
+    $prevVersion = $curVersion;
+  }
   if (($prevVersion ne $curVersion )) {
     progress ("Upgrading from $prevVersion to $curVersion\n");
     open (H, ">>/opt/zimbra/.install_history");


### PR DESCRIPTION
When performing a new install of ZCS by running `install.sh`
with a supplied defaults file the upgrade check performed during
the subsequent call to this...

    /opt/zimbra/libexec/zmsetup.pl -c $DEFAULTFILE

...fails because `$prevVersion` is empty. By setting
`$prevVersion` to `$curVersion` if it is empty, the configuration
that is performed by `zmsetup.pl` is allow to complete, with no
upgrade attempted (as is appropriate for a new install).