### PR TITLE
Added ant-junit CentOS 7 package to setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ logged in as a non-root user with `sudo` privileges.
 ### CentOS 7
 
     sudo yum groupinstall 'Development Tools'
-    sudo yum install java-1.8.0-openjdk ant ruby git maven cpan wget perl-IPC-Cmd
+    sudo yum install java-1.8.0-openjdk ant ant-junit ruby git maven cpan wget perl-IPC-Cmd
 
 ### CentOS 6
 


### PR DESCRIPTION
Added package ant-junit for CentOS 7 to the system setup instructions on line 49. Not having ant-junit will fail the build process with a class not found error.