### PR TITLE
ZCS-2839 and ZCS-2885 zimbra-imapd installation

### DIFF
--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -2309,27 +2309,27 @@ getInstallPackages() {
       if [ $i = "zimbra-archiving" ]; then
         if [ $STORE_SELECTED = "yes" ]; then
           askYN "Install $i" "N"
-	fi
-      
+        fi
+
       elif [ $i = "zimbra-chat" ]; then
         if [ $STORE_SELECTED = "yes" ]; then
           askYN "Install $i" "N"
-	fi
+        fi
 
       elif [ $i = "zimbra-drive" ]; then
         if [ $STORE_SELECTED = "yes" ]; then
           askYN "Install $i" "N"
-	fi
+        fi
 
       elif [ $i = "zimbra-network-modules-ng" ]; then
         if [ $STORE_SELECTED = "yes" ]; then
           askYN "Install $i" "N"
-	fi
+        fi
 
       else
         askYN "Install $i" "N"
       fi
-      
+
     else
 
       if [ $i = "zimbra-archiving" ]; then
@@ -2360,6 +2360,9 @@ getInstallPackages() {
           askYN "Install $i" "Y"
         fi
 
+      elif [ $i = "zimbra-imapd" ]; then
+          askYN "Install $i (BETA - for evaluation only)" "N"
+
       elif [ $i = "zimbra-dnscache" ]; then
         if [ $MTA_SELECTED = "yes" ]; then
           askYN "Install $i" "Y"
@@ -2381,7 +2384,7 @@ getInstallPackages() {
       elif [ $i = "zimbra-mta" ]; then
         MTA_SELECTED="yes"
       fi
-      
+
       if [ $i = "zimbra-network-modules-ng" ]; then
           echo "###WARNING###"
           echo ""

--- a/rpmconf/Install/zmsetup.pl
+++ b/rpmconf/Install/zmsetup.pl
@@ -7127,7 +7127,7 @@ sub applyConfig {
   setLdapServerConfig($config{HOSTNAME}, 'zimbraServerVersionType', $curVersionType);
   setLdapServerConfig($config{HOSTNAME}, 'zimbraServerVersionBuild', $curVersionBuild);
 
-  if ($newinstall && isEnabled("zimbra-imapd")) {
+  if (isEnabled("zimbra-imapd")) {
     configImap();
   }
 


### PR DESCRIPTION
Upgraded from 8.7.6_GA_1776 - first selecting to install zimbra-imapd
then selecting not to install it.

In the first case, zimbra-imapd runs but doesn't do anything, imapd.log contains the line:

    imap - ImapDaemon: This server not member of pool. Check zimbraReverseProxyUpstreamImapServers.

`zmcontrol status` reports the daemon  as Running.

Confirmed using openssl that connected to the embedded IMAP server and select a folder.  With IMAP tracing enabled, confirmed that the local variant was in use.

With the 2nd installation, confirmed that the imap daemon is not referenced in `zmcontrol status`
and no imapd.log file is created.  Again, confirmed that openssl connects to the embedded local IMAP server and can select a folder.

The above is the desired behavior as I understand it.