### PR TITLE
ZCS-3226: Updated NG parameter in fresh install as per new changes.

### DIFF
--- a/rpmconf/Install/zmsetup.pl
+++ b/rpmconf/Install/zmsetup.pl
@@ -7147,6 +7147,8 @@ sub applyConfig {
 
     if (!isInstalled("zimbra-network-modules-ng")) {
       setLdapServerConfig($config{HOSTNAME}, 'zimbraNetworkModulesNGEnabled', 'FALSE');
+    } else {
+      setLdapServerConfig($config{HOSTNAME}, 'zimbraNetworkModulesNGEnabled', 'TRUE');
     }
 
     if (isInstalled("zimbra-network-modules-ng") && $newinstall) {

--- a/rpmconf/Install/zmsetup.pl
+++ b/rpmconf/Install/zmsetup.pl
@@ -7145,11 +7145,14 @@ sub applyConfig {
       }
     }
 
+    if (!isInstalled("zimbra-network-modules-ng")) {
+      setLdapServerConfig($config{HOSTNAME}, 'zimbraNetworkModulesNGEnabled', 'FALSE');
+    }
+
     if (isInstalled("zimbra-network-modules-ng") && $newinstall) {
-      main::progress("Enabling zimbra network NG modules features: Backup, HSM and Mobile\n");
+      main::progress("Enabling zimbra network NG modules features.\n");
       setLdapServerConfig($config{HOSTNAME}, 'zimbraNetworkMobileNGEnabled', 'TRUE');
-      setLdapServerConfig($config{HOSTNAME}, 'zimbraNetworkBackupNGEnabled', 'TRUE');
-      setLdapServerConfig($config{HOSTNAME}, 'zimbraNetworkHSMNGEnabled', 'TRUE');
+      setLdapServerConfig($config{HOSTNAME}, 'zimbraNetworkAdminNGEnabled', 'TRUE');
     }
 
     progress ( "Starting servers..." );


### PR DESCRIPTION
* If zimbra-network-modules-ng not installed zimbraNetwork(Modules/Mobile/Admin)NGEnabled is false.
* Fresh install with zimbra-network-modules-ng zimbraNetwork(Modules/Mobile/Admin)NGEnabled is true.
* Upgrade with zimbra-network-modules-ng zimbraNetworkModulesNGEnabled is true where as mobile and admin false.