### PR TITLE
ZCS-3269 zimbraImapLoadBalancingAlgorithm corrected in config

### DIFF
--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -2331,6 +2331,9 @@ getInstallPackages() {
           INSTALL_PACKAGES="$INSTALL_PACKAGES zimbra-rpost"
         fi
 
+      elif [ $i = "zimbra-imapd" ]; then
+        askYN "Install $i (BETA - for evaluation only)" "N"
+
       else
         askYN "Install $i" "N"
       fi

--- a/rpmconf/Upgrade/zmupgrade.pm
+++ b/rpmconf/Upgrade/zmupgrade.pm
@@ -2562,6 +2562,7 @@ sub upgradeLdap($) {
           close(OUT);
           close(IN);
           qx(mv $outfile $infile);
+          qx(chown zimbra:zimbra $infile);
         }
         main::configLog("LdapUpgraded$upgradeVersion");
       }
@@ -2609,6 +2610,7 @@ sub upgradeLdap($) {
           close(OUT);
           close(IN);
           qx(mv $outfile $infile);
+          qx(chown zimbra:zimbra $infile);
         }
         main::configLog("LdapUpgraded$upgradeVersion");
       }
@@ -2693,6 +2695,7 @@ sub upgradeLdap($) {
             close(OUT);
             close(IN);
             qx(mv $outfile $infile);
+            qx(chown zimbra:zimbra $infile);
           }
           if (-f '/opt/zimbra/data/ldap/config/cn=config.ldif') {
             $infile="/opt/zimbra/data/ldap/config/cn\=config.ldif";

--- a/rpmconf/Upgrade/zmupgrade.pm
+++ b/rpmconf/Upgrade/zmupgrade.pm
@@ -119,6 +119,7 @@ my %updateFuncs = (
   "8.7.0_BETA2" => \&upgrade870BETA2,
   "8.7.0_RC1" => \&upgrade870RC1,
   "8.7.2_GA" => \&upgrade872GA,
+  "8.8.6_GA" => \&upgrade886GA,
 );
 
 my %updateMysql = (
@@ -2057,6 +2058,8 @@ sub upgrade886GA {
         # behavior for all upgrades until the administrator decides to enable the strict name enforcement.
         main::setLdapServerConfig($hn, 'zimbraReverseProxyStrictServerNameEnabled', "FALSE");
     }
+    # ClientIpHash is now obsolete
+    upgradeLdapConfigValue("zimbraImapLoadBalancingAlgorithm", "AccountIdHash", "ClientIpHash");
     return 0;
 }
 


### PR DESCRIPTION
On upgrade, see this in the logs and the right value is set afterwards:
    zmsetup.log:Thu Oct 26 14:30:25 2017 *** Running as zimbra user: /opt/zimbra/bin/zmprov -r -m -l mcf  zimbraImapLoadBalancingAlgorithm 'AccountIdHash'