### PR TITLE
ZCS-2189 retrieve ephemeral settings from ldap

### DIFF
--- a/rpmconf/Install/zmsetup.pl
+++ b/rpmconf/Install/zmsetup.pl
@@ -1234,6 +1234,9 @@ sub setLdapDefaults {
       if ($config{zimbraVersionCheckNotificationEmailFrom} eq "");
   }
 
+  $config{EphemeralBackendURL} = getLdapConfigValue("zimbraEphemeralBackendURL");
+  $config{USEEPHEMERALSTORE} = "yes" if ($config{EphemeralBackendURL} ne "");
+
   #
   # Load default COS
   #


### PR DESCRIPTION
Update to zmsetup.pl to fetch the global value of `zimbraEphemeralBackendURL` from LDAP if it is set during the installation of nodes which connect to LDAP to pre-populate installer settings.

This ensures that the menu option shows that it will be using an external ephemeral backend and also displays the current setting for the option.

Note: I decided I didn't want to distinguish between a user setting the value and the installer populating the existing value into the options.  If this is desired it can be accomplished with some additional changes.