### PR TITLE
Add ant-optional to Ubuntu build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The following steps assume that your are starting with a clean VM and are
 logged in as a non-root user with `sudo` privileges.
 
     sudo apt-get update
-    sudo apt-get install software-properties-common openjdk-8-jdk ant ruby git maven build-essential
+    sudo apt-get install software-properties-common openjdk-8-jdk ant ant-optional ant-contrib ruby git maven build-essential
 
 ### Ubuntu 14.04
 
@@ -33,7 +33,7 @@ logged in as a non-root user with `sudo` privileges.
     sudo add-apt-repository ppa:openjdk-r/ppa
     sudo apt-get update
     sudo update-ca-certificates -f
-    sudo apt-get install openjdk-8-jdk ant ruby git maven build-essential
+    sudo apt-get install openjdk-8-jdk ant ant-optional ant-contrib ruby git maven build-essential
 
 ### Ubuntu 12.04
 
@@ -41,7 +41,7 @@ logged in as a non-root user with `sudo` privileges.
     sudo add-apt-repository ppa:openjdk-r/ppa
     sudo apt-get update
     sudo update-ca-certificates -f
-    sudo apt-get install openjdk-8-jdk ant ruby git maven build-essential zlib1g-dev
+    sudo apt-get install openjdk-8-jdk ant ant-optional ant-contrib ruby git maven build-essential zlib1g-dev
 
 ### CentOS 7
 


### PR DESCRIPTION
Without this package the build of `zm-mailbox` will fail with the error

    BUILD FAILED
    /home/build/installer-build/zm-mailbox/build.xml:32: The following error occurred while executing this line:
    /home/build/installer-build/zm-mailbox/build-common.xml:305: Problem: failed to create task or type junit
    Cause: the class org.apache.tools.ant.taskdefs.optional.junit.JUnitTask was not found.
            This looks like one of Ant's optional components.