### PR TITLE
Point the App1 upgrade EC2_TARGET environment variable to APP1 instead of APP2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,7 +200,7 @@ jobs:
       working_directory: ~/checkout/zm-build
       shell: /bin/bash -euo pipefail
       environment:
-         - EC2_TARGET: APP2
+         - EC2_TARGET: APP1
          - OPERATION: upgrade
          - PKG_OS_TAG: u16
       docker:


### PR DESCRIPTION
Just looks like it was a bug in the config