### PR TITLE
HA mailbox, build configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .build.last_no_ts
 .build.number
-config.build
 RE/BUILD
 RE/MAJOR
 RE/MICRO

--- a/config.build.in
+++ b/config.build.in
@@ -8,8 +8,15 @@ BUILD_RELEASE_CANDIDATE = GA
 BUILD_TYPE              = FOSS
 BUILD_THIRDPARTY_SERVER = zdev-vm008.eng.zimbra.com
 
+GIT_DEFAULT_BRANCH = develop
+ANT_OPTIONS = -DskipTests=1
+INTERACTIVE = 0
+DISABLE_BUNDLE = 1
+
 # Example of GIT_OVERRIDES (hash)
 # %GIT_OVERRIDES          = myremote.url-prefix=ssh://git@stash.corp.synacor.com:7999/~user/zm-mailbox.git
-# %GIT_OVERRIDES          = zm-mailbox.branch=dev
+%GIT_OVERRIDES = zm-db-conf.branch=feature/ha-redolog
+%GIT_OVERRIDES = zm-mailbox.branch=feature/ha
+%GIT_OVERRIDES = zm-zcs-lib.branch=feature/solr
 # %GIT_OVERRIDES          = zm-mailbox.remote=myremote
 # %GIT_OVERRIDES          = zm-mailbox.tag=judaspriest-872    # .tag always overrides .branch

--- a/instructions/bundling-scripts/zimbra-core.sh
+++ b/instructions/bundling-scripts/zimbra-core.sh
@@ -484,6 +484,8 @@ main()
    Copy ${repoDir}/zm-db-conf/src/db/migration/migrate20150702-ZmgDevices.pl                        ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/scripts/migrate20150702-ZmgDevices.pl
    Copy ${repoDir}/zm-db-conf/src/db/migration/migrate20170301-ZimbraChat.pl                        ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/scripts/migrate20170301-ZimbraChat.pl
    Copy ${repoDir}/zm-db-conf/src/db/migration/migrate20180301-ZimbraChat.pl                        ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/scripts/migrate20180301-ZimbraChat.pl
+   Copy ${repoDir}/zm-db-conf/src/db/migration/migrate20170829-SearchHistory.pl                     ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/scripts/migrate20170829-SearchHistory.pl
+   Copy ${repoDir}/zm-db-conf/src/db/migration/migrate20180110-DistributedRedolog.pl                ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/scripts/migrate20180110-DistributedRedolog.pl
    Copy ${repoDir}/zm-db-conf/src/db/migration/migrateAmavisLdap20050810.pl                         ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/scripts/migrateAmavisLdap20050810.pl
    Copy ${repoDir}/zm-db-conf/src/db/migration/migrateClearSpamFlag.pl                              ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/scripts/migrateClearSpamFlag.pl
    Copy ${repoDir}/zm-db-conf/src/db/migration/migrateLargeMetadata.pl                              ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/scripts/migrateLargeMetadata.pl

--- a/rpmconf/Upgrade/zmupgrade.pm
+++ b/rpmconf/Upgrade/zmupgrade.pm
@@ -41,7 +41,7 @@ chomp $rundir;
 my $scriptDir = "/opt/zimbra/libexec/scripts";
 
 my $lowVersion = 52;
-my $hiVersion = 110; # this should be set to the DB version expected by current server code
+my $hiVersion = 111; # this should be set to the DB version expected by current server code
 
 my $needSlapIndexing = 0;
 my $mysqlcnfUpdated = 0;
@@ -86,6 +86,7 @@ my %updateScripts = (
   '107' => "migrate20170301-ZimbraChat.pl",            #8.7.6
   '108' => "migrate20180301-ZimbraChat.pl",            #8.8.8
   '109' => "migrate20170829-SearchHistory.pl",
+  '110' => "migrate20180110-DistributedRedolog.pl",
 );
 
 my %updateFuncs = (


### PR DESCRIPTION
This is the build configuration used by Zimbra/zm-docker#26. It build's `zm-mailbox` using the high availability (`feature/ha`) branch. That build is used to provision the HA reference environment in `docker swarm`.