### PR TITLE
ZCS-4346, ZCS-4315 Remove zkclient from zimbra-core

### DIFF
--- a/instructions/bundling-scripts/zimbra-core.sh
+++ b/instructions/bundling-scripts/zimbra-core.sh
@@ -698,7 +698,6 @@ main()
       "xercesImpl-2.9.1-patch-01.jar"
       "xmlschema-core-2.0.3.jar"
       "yuicompressor-2.4.2-zimbra.jar"
-      "zkclient-0.1.0.jar"
       "zm-ews-stub-2.0.jar"
       "zookeeper-3.4.5.jar"
    )


### PR DESCRIPTION
This library is not actually used and its presence is
creating a conflict with the ZooKeeper library we are using.