### PR TITLE
Task/zcs 4381

### DIFF
--- a/rpmconf/Install/zmsetup.pl
+++ b/rpmconf/Install/zmsetup.pl
@@ -134,6 +134,12 @@ our $curVersion = "";
 my ($prevVersionMinor,$prevVersionMajor,$prevVersionMicro,$prevVersionBuild);
 my ($curVersionMinor,$curVersionMajor,$curVersionMicro,$curVersionMicroMicro,$curVersionType,$curVersionBuild);
 our $newinstall = 1;
+chomp (my $ldapSchemaVersion = do {
+    local $/ = undef;
+    open my $fh, "<", "/opt/zimbra/conf/zimbra-attrs-schema"
+        or die "could not open /opt/zimbra/conf/zimbra-attrs-schema: $!";
+    <$fh>;
+});
 
 my $ldapConfigured = 0;
 my $ldapRunning = 0;
@@ -7102,6 +7108,9 @@ sub applyConfig {
     # 32295
     setLdapGlobalConfig("zimbraSkinLogoURL", "http://www.zimbra.com")
       if isFoss();
+
+    progress ("Updating zimbraLDAPSchemaVersion to version '$ldapSchemaVersion'\n");
+    setLdapGlobalConfig('zimbraLDAPSchemaVersion', $ldapSchemaVersion);
   }
 
   if ($newinstall && isInstalled("zimbra-proxy")) {


### PR DESCRIPTION
Accidentally closed the old PR.

This PR reads in the zimbra-attrs-schema file and uses it's value to update the `zimbraLDAPSchemaVersion` LDAP attribute.

Will likely be moving the file from conf/attrs/ -> conf/ in order to avoid the WARNING message about a non-XML file being found on EVERY run of zmprov.