### PR TITLE
ZCS-4353 Adding back rsync for zm-zcs-lib

### DIFF
--- a/instructions/FOSS_staging_list.pl
+++ b/instructions/FOSS_staging_list.pl
@@ -338,6 +338,9 @@
    {
       "dir"         => "zm-zcs-lib",
       "ant_targets" => ["dist", "pkg"],
+      "stage_cmd"   => sub {
+         SysExec("(cd .. && rsync -az --relative zm-zcs-lib $CFG{BUILD_DIR}/)");
+      },
       "deploy_pkg_into" => "bundle",
    },
    {


### PR DESCRIPTION
Fixing the error while copying jedis jar while creating core pkg
