### PR TITLE
Updated expected schema version to 109.

### DIFF
--- a/rpmconf/Upgrade/zmupgrade.pm
+++ b/rpmconf/Upgrade/zmupgrade.pm
@@ -41,7 +41,7 @@ chomp $rundir;
 my $scriptDir = "/opt/zimbra/libexec/scripts";
 
 my $lowVersion = 52;
-my $hiVersion = 108; # this should be set to the DB version expected by current server code
+my $hiVersion = 109; # this should be set to the DB version expected by current server code
 
 my $needSlapIndexing = 0;
 my $mysqlcnfUpdated = 0;


### PR DESCRIPTION
This was causing the schema updates for zextras to not be installed and thus breaking upgrade.