### PR TITLE
use rpm instead of yum for install

### DIFF
--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -2713,7 +2713,7 @@ getPlatformVars() {
       ISUBUNTU=false
       REPOINST='yum -y install'
       REPORM='yum erase -y'
-      PACKAGEINST='yum -y --disablerepo=* localinstall -v'
+      PACKAGEINST='rpm -Uvh --replacefiles'
       # TODO: This should kept in os-requirement.
       yum -y install --downloadonly dummyxxxxxxx 2>&1 | grep "no such option: --downloadonly" >/dev/null 2>&1
       if [ $? -eq 0 ]; then


### PR DESCRIPTION
This change was suggested by Prashant as a temporary method to get around the fact that we are including the same files in multiple RPMs which RPM correctly identifies as a conflict.

Since they are exactly the same file it was decided that it doesn't matter which package ultimately places the file on disk since each file that has a conflict is exactly the same in both packages.

Note: This appears to have ramifications to the upgrade process from 8.8.7 at this time.  This is unfortunate since this is the case it was intended to resolve.  This is being opened to get additional eyes on this.