### PR TITLE
zimbraReverseProxyStrictServerNameEnabled is not a multivalued attribute

### DIFF
--- a/rpmconf/Install/zmsetup.pl
+++ b/rpmconf/Install/zmsetup.pl
@@ -6234,11 +6234,11 @@ sub configSetProxyPrefs {
    if (isEnabled("zimbra-proxy")) {
      if ($config{STRICTSERVERNAMEENABLED} eq "yes") {
         progress("Enabling strict server name enforcement on $config{HOSTNAME}...");
-        runAsZimbra("$ZMPROV ms $config{HOSTNAME} +zimbraReverseProxyStrictServerNameEnabled TRUE");
+        runAsZimbra("$ZMPROV ms $config{HOSTNAME} zimbraReverseProxyStrictServerNameEnabled TRUE");
         progress("done.\n");
      } else {
         progress("Disabling strict server name enforcement on $config{HOSTNAME}...");
-        runAsZimbra("$ZMPROV ms $config{HOSTNAME} +zimbraReverseProxyStrictServerNameEnabled FALSE");
+        runAsZimbra("$ZMPROV ms $config{HOSTNAME} zimbraReverseProxyStrictServerNameEnabled FALSE");
         progress("done.\n");
      }
      if ($config{MAILPROXY} eq "FALSE" && $config{HTTPPROXY} eq "FALSE") {


### PR DESCRIPTION
… multiple value field in zmsetup.pl

One of the commits where this problem was introduced was: 3e59e1604f6fb042cb1a88f32259479b7c383d6f
( ZCS-3192 add strict server name enforcement to installer  )