### PR TITLE
ZCS-4465

### DIFF
--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -2694,7 +2694,7 @@ getPlatformVars() {
     REPOINST='apt-get install -y'
     PACKAGEDOWNLOAD='apt-get --download-only install -y --force-yes'
     REPORM='apt-get -y --purge purge'
-    PACKAGEINST='dpkg -i'
+    PACKAGEINST='dpkg -i --auto-deconfigure'
     PACKAGERM='dpkg --purge'
     PACKAGERMSIMULATE='dpkg --purge --dry-run'
     PACKAGEQUERY='dpkg -s'


### PR DESCRIPTION
- When any package is removed then make sure to auto configure other packages to remove it's dependency
- This is required for removing admin common package and instead move all files to admin console package