### PR TITLE
ZCS-5263 [Bugfix]

### DIFF
--- a/rpmconf/Install/Util/globals.sh
+++ b/rpmconf/Install/Util/globals.sh
@@ -37,13 +37,16 @@ zimbra-archiving"
 SERVICES=""
 
 OPTIONAL_PACKAGES="zimbra-qatest \
-zimbra-chat \
 zimbra-drive \
 zimbra-imapd \
+zimbra-patch \
 zimbra-license-tools \
 zimbra-license-extension \
 zimbra-network-store \
 zimbra-network-modules-ng"
+
+CHAT_PACKAGES="zimbra-chat \
+zimbra-talk"
 
 PACKAGE_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)/packages"
 

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -674,6 +674,14 @@ checkExistingInstall() {
     fi
   done
 
+  for i in $CHAT_PACKAGES; do
+    isInstalled $i
+    if [ x$PKGINSTALLED != "x" ]; then
+      echo "    $i...FOUND $PKGINSTALLED"
+      INSTALLED_PACKAGES="$INSTALLED_PACKAGES $i"
+    fi
+  done
+
   for i in $PACKAGES $CORE_PACKAGES; do
     echo -n "    $i..."
     isInstalled $i
@@ -1650,6 +1658,10 @@ findUbuntuExternalPackageDependencies() {
     if [ x$PKGINSTALLED != "x" ]; then
       INSTALLED_PACKAGES="$INSTALLED_PACKAGES zimbra-talk"
     fi
+    isInstalled "zimbra-chat"
+    if [ x$PKGINSTALLED != "x" ]; then
+      INSTALLED_PACKAGES="$INSTALLED_PACKAGES zimbra-chat"
+    fi
     $PACKAGERMSIMULATE $INSTALLED_PACKAGES > /dev/null 2>&1
     if [ $? -ne 0 ]; then
       EXTPACKAGESTMP=`$PACKAGERMSIMULATE $INSTALLED_PACKAGES 2>&1 | grep " depends on " | cut -d' ' -f2 | grep -v zimbra`
@@ -1736,6 +1748,13 @@ removeExistingPackages() {
       if [ x$PKGINSTALLED != "x" ]; then
         echo -n "   zimbra-talk..."
         $PACKAGERM zimbra-talk >/dev/null 2>&1
+        echo "done"
+      fi
+
+      isInstalled "zimbra-patch"
+      if [ x$PKGINSTALLED != "x" ]; then
+        echo -n "   zimbra-patch..."
+        $PACKAGERM zimbra-patch >/dev/null 2>&1
         echo "done"
       fi
 
@@ -2288,6 +2307,24 @@ EOF
   fi
 }
 
+getChatOrTalkPackage() {
+
+ if [ $response = "yes" ]; then
+    askInstallPkgYN "Install zimbra-talk" "yes" "Y" "N"
+    if [ $response = "yes" ]; then
+       INSTALL_PACKAGES="$INSTALL_PACKAGES zimbra-talk"
+    elif [ $response = "no" ]; then
+       response="yes"
+    fi
+  elif [ $response = "no" ]; then
+    askInstallPkgYN "Install zimbra-chat" "yes" "Y" "N"
+    if [ $response = "yes" ]; then
+       INSTALL_PACKAGES="$INSTALL_PACKAGES zimbra-chat"
+       response="no"
+    fi
+ fi
+}
+
 getInstallPackages() {
 
   echo ""
@@ -2355,6 +2392,8 @@ getInstallPackages() {
 
     if [ $i = "zimbra-license-tools" ]; then
       response="yes"
+    elif [ $i = "zimbra-patch" ]; then
+      response="yes"
     elif [ $i = "zimbra-license-extension" ]; then
       ifStoreSelectedY
     elif [ $i = "zimbra-network-store" ]; then
@@ -2368,6 +2407,7 @@ getInstallPackages() {
         askInstallPkgYN "Install $i" "yes" "N" "N"
       elif [ $i = "zimbra-network-modules-ng" ]; then
         askInstallPkgYN "Install $i" "yes" "N" "N"
+	getChatOrTalkPackage
       elif [ $i = "zimbra-imapd" ]; then
         askInstallPkgYN "Install $i (BETA - for evaluation only)" "no" "N" "N"
       else
@@ -2384,6 +2424,7 @@ getInstallPackages() {
         askInstallPkgYN "Install $i" "yes" "Y" "N"
       elif [ $i = "zimbra-network-modules-ng" ]; then
         askInstallPkgYN "Install $i" "yes" "Y" "N"
+	getChatOrTalkPackage
       elif [ $i = "zimbra-imapd" ]; then
         askInstallPkgYN "Install $i (BETA - for evaluation only)" "no" "N" "N"
       elif [ $i = "zimbra-dnscache" ]; then
@@ -2694,7 +2735,7 @@ getPlatformVars() {
     REPOINST='apt-get install -y'
     PACKAGEDOWNLOAD='apt-get --download-only install -y --force-yes'
     REPORM='apt-get -y --purge purge'
-    PACKAGEINST='dpkg -i --auto-deconfigure'
+    PACKAGEINST='dpkg -i'
     PACKAGERM='dpkg --purge'
     PACKAGERMSIMULATE='dpkg --purge --dry-run'
     PACKAGEQUERY='dpkg -s'

--- a/rpmconf/Install/zmsetup.pl
+++ b/rpmconf/Install/zmsetup.pl
@@ -7191,10 +7191,10 @@ sub applyConfig {
       }
     }
 
-    if (!isInstalled("zimbra-network-modules-ng")) {
-      setLdapServerConfig($config{HOSTNAME}, 'zimbraNetworkModulesNGEnabled', 'FALSE');
-    } else {
-      setLdapServerConfig($config{HOSTNAME}, 'zimbraNetworkModulesNGEnabled', 'TRUE');
+    if (isInstalled("zimbra-network-modules-ng")) {
+       if ($prevVersionMajor <= 8 && $prevVersionMinor <= 7) {
+        setLdapServerConfig($config{HOSTNAME}, 'zimbraNetworkModulesNGEnabled', 'TRUE');
+        }
     }
 
     if (isInstalled("zimbra-network-modules-ng") && $newinstall) {


### PR DESCRIPTION
**[Bugfix#1]** zimbraNetworkModulesNGEnabled was always set to 'TRUE' by the zmsetup.pl
**Problem:** While upgrading to new version after 8.7.x _zimbraNetworkModulesNGEnabled_ was always set to 'TRUE' by the _zmsetup.pl_ script.

**Approach and Fix:** In the zmsetup.pl script while upgrading if the previous version is <= 8.7.x then _zimbraNetworkModulesNGEnabled_ is set to 'TRUE'

**Testing done:** 
1. Installed fresh 8.7.11_GA_1854 and there was no attribute present as  _zimbraNetworkModulesNGEnabled_
2. Upgraded from 8.7.11_GA_1854 to 8.8.8_GA_2009 _zimbraNetworkModulesNGEnabled_ was set to 'TRUE'
3. Manually set _zimbraNetworkModulesNGEnabled_ to 'FALSE' on 8.8.8_GA_2009
    Re-ran the _zmsetup.pl_ _zimbraNetworkModulesNGEnabled_retained to 'FALSE'
4. Upgraded from 8.8.8_GA_2009 to 8.8.9_GA_1731 _zimbraNetworkModulesNGEnabled_ remained 'FALSE'
5. Manually set _zimbraNetworkModulesNGEnabled_ to 'TRUE' on 8.8.9_GA_1731
    Re-ran the _zmsetup.pl_ _zimbraNetworkModulesNGEnabled_retained to 'TRUE'

----------------------------------------------------------------------------------------------------
**[Bugfix#2]**
**Problem:** 1. Add zimbra-patch package for installation and prompt the user for its Yes/No for its installation. 
                       2. If zimbra-patch was installed from the repos then uninstallation was failing.

**Approach and Fix:**  zimbra-patch was added to _OPTIONAL_PACKAGES_ in _global.sh_  and added procedure for uninstallation of zimbra-patch in _utilfunc.sh_ file if zimbra-patch is already installed.

**Testing done:** 
1. For testing _uninstallation_
a. Manually installed zimbra-patch and ran `intstall.sh -u` and the patch was uninstallation was successful as compared to prior it was failing at this step.
b. If the package was installed automatically by adding it to  _OPTIONAL_PACKAGES_ in _global.sh_ uninstallation was successful.
 
2. For testing _installation_
a. Installation was successful with zimbra-patch by adding it to  _OPTIONAL_PACKAGES_ in _global.sh_
b. Tested for both the case of Yes and No prompt while installation.