### PR TITLE
Feature/5263 Install zimbra-chat or zimbra-talk based on zimbra-network-modules-ng selection while Installation

### DIFF
--- a/rpmconf/Install/Util/globals.sh
+++ b/rpmconf/Install/Util/globals.sh
@@ -37,13 +37,16 @@ zimbra-archiving"
 SERVICES=""
 
 OPTIONAL_PACKAGES="zimbra-qatest \
-zimbra-chat \
 zimbra-drive \
 zimbra-imapd \
+zimbra-patch \
 zimbra-license-tools \
 zimbra-license-extension \
 zimbra-network-store \
 zimbra-network-modules-ng"
+
+CHAT_PACKAGES="zimbra-chat \
+zimbra-talk"
 
 PACKAGE_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)/packages"
 

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -1654,14 +1654,12 @@ saveExistingConfig() {
 findUbuntuExternalPackageDependencies() {
   # Handle external packages like logwatch, mailutils depends on zimbra-mta.
   if [ $INSTALLED = "yes" -a $ISUBUNTU = "true" ]; then
-    isInstalled "zimbra-talk"
-    if [ x$PKGINSTALLED != "x" ]; then
-      INSTALLED_PACKAGES="$INSTALLED_PACKAGES zimbra-talk"
-    fi
-    isInstalled "zimbra-chat"
-    if [ x$PKGINSTALLED != "x" ]; then
-      INSTALLED_PACKAGES="$INSTALLED_PACKAGES zimbra-chat"
-    fi
+    for i in $CHAT_PACKAGES; do
+      isInstalled $i
+     if [ x$PKGINSTALLED != "x" ]; then
+      INSTALLED_PACKAGES="$INSTALLED_PACKAGES $i"
+     fi
+    done
     $PACKAGERMSIMULATE $INSTALLED_PACKAGES > /dev/null 2>&1
     if [ $? -ne 0 ]; then
       EXTPACKAGESTMP=`$PACKAGERMSIMULATE $INSTALLED_PACKAGES 2>&1 | grep " depends on " | cut -d' ' -f2 | grep -v zimbra`
@@ -2353,6 +2351,9 @@ getInstallPackages() {
       echo $INSTALLED_PACKAGES | grep $i > /dev/null 2>&1
       if [ $? = 0 ]; then
         echo "    Upgrading $i"
+        if [ $i = "zimbra-network-modules-ng" ]; then
+          INSTALL_PACKAGES="$INSTALL_PACKAGES zimbra-talk"
+        fi
         if [ $i = "zimbra-mta" ]; then
           CONFLICTS="no"
           for j in $CONFLICT_PACKAGES; do

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -674,6 +674,14 @@ checkExistingInstall() {
     fi
   done
 
+  for i in $CHAT_PACKAGES; do
+    isInstalled $i
+    if [ x$PKGINSTALLED != "x" ]; then
+      echo "    $i...FOUND $PKGINSTALLED"
+      INSTALLED_PACKAGES="$INSTALLED_PACKAGES $i"
+    fi
+  done
+
   for i in $PACKAGES $CORE_PACKAGES; do
     echo -n "    $i..."
     isInstalled $i
@@ -1650,6 +1658,10 @@ findUbuntuExternalPackageDependencies() {
     if [ x$PKGINSTALLED != "x" ]; then
       INSTALLED_PACKAGES="$INSTALLED_PACKAGES zimbra-talk"
     fi
+    isInstalled "zimbra-chat"
+    if [ x$PKGINSTALLED != "x" ]; then
+      INSTALLED_PACKAGES="$INSTALLED_PACKAGES zimbra-chat"
+    fi
     $PACKAGERMSIMULATE $INSTALLED_PACKAGES > /dev/null 2>&1
     if [ $? -ne 0 ]; then
       EXTPACKAGESTMP=`$PACKAGERMSIMULATE $INSTALLED_PACKAGES 2>&1 | grep " depends on " | cut -d' ' -f2 | grep -v zimbra`
@@ -1736,6 +1748,13 @@ removeExistingPackages() {
       if [ x$PKGINSTALLED != "x" ]; then
         echo -n "   zimbra-talk..."
         $PACKAGERM zimbra-talk >/dev/null 2>&1
+        echo "done"
+      fi
+
+      isInstalled "zimbra-patch"
+      if [ x$PKGINSTALLED != "x" ]; then
+        echo -n "   zimbra-patch..."
+        $PACKAGERM zimbra-patch >/dev/null 2>&1
         echo "done"
       fi
 
@@ -2288,6 +2307,24 @@ EOF
   fi
 }
 
+getChatOrTalkPackage() {
+
+ if [ $response = "yes" ]; then
+    askInstallPkgYN "Install zimbra-talk" "yes" "Y" "N"
+    if [ $response = "yes" ]; then
+       INSTALL_PACKAGES="$INSTALL_PACKAGES zimbra-talk"
+    elif [ $response = "no" ]; then
+       response="yes"
+    fi
+  elif [ $response = "no" ]; then
+    askInstallPkgYN "Install zimbra-chat" "yes" "Y" "N"
+    if [ $response = "yes" ]; then
+       INSTALL_PACKAGES="$INSTALL_PACKAGES zimbra-chat"
+       response="no"
+    fi
+ fi
+}
+
 getInstallPackages() {
 
   echo ""
@@ -2355,6 +2392,8 @@ getInstallPackages() {
 
     if [ $i = "zimbra-license-tools" ]; then
       response="yes"
+    elif [ $i = "zimbra-patch" ]; then
+      response="yes"
     elif [ $i = "zimbra-license-extension" ]; then
       ifStoreSelectedY
     elif [ $i = "zimbra-network-store" ]; then
@@ -2368,6 +2407,7 @@ getInstallPackages() {
         askInstallPkgYN "Install $i" "yes" "N" "N"
       elif [ $i = "zimbra-network-modules-ng" ]; then
         askInstallPkgYN "Install $i" "yes" "N" "N"
+	getChatOrTalkPackage
       elif [ $i = "zimbra-imapd" ]; then
         askInstallPkgYN "Install $i (BETA - for evaluation only)" "no" "N" "N"
       else
@@ -2384,6 +2424,7 @@ getInstallPackages() {
         askInstallPkgYN "Install $i" "yes" "Y" "N"
       elif [ $i = "zimbra-network-modules-ng" ]; then
         askInstallPkgYN "Install $i" "yes" "Y" "N"
+	getChatOrTalkPackage
       elif [ $i = "zimbra-imapd" ]; then
         askInstallPkgYN "Install $i (BETA - for evaluation only)" "no" "N" "N"
       elif [ $i = "zimbra-dnscache" ]; then
@@ -2694,7 +2735,7 @@ getPlatformVars() {
     REPOINST='apt-get install -y'
     PACKAGEDOWNLOAD='apt-get --download-only install -y --force-yes'
     REPORM='apt-get -y --purge purge'
-    PACKAGEINST='dpkg -i --auto-deconfigure'
+    PACKAGEINST='dpkg -i'
     PACKAGERM='dpkg --purge'
     PACKAGERMSIMULATE='dpkg --purge --dry-run'
     PACKAGEQUERY='dpkg -s'

--- a/rpmconf/Install/zmsetup.pl
+++ b/rpmconf/Install/zmsetup.pl
@@ -7191,10 +7191,10 @@ sub applyConfig {
       }
     }
 
-    if (!isInstalled("zimbra-network-modules-ng")) {
-      setLdapServerConfig($config{HOSTNAME}, 'zimbraNetworkModulesNGEnabled', 'FALSE');
-    } else {
-      setLdapServerConfig($config{HOSTNAME}, 'zimbraNetworkModulesNGEnabled', 'TRUE');
+    if (isInstalled("zimbra-network-modules-ng")) {
+       if ($prevVersionMajor <= 8 && $prevVersionMinor <= 7) {
+        setLdapServerConfig($config{HOSTNAME}, 'zimbraNetworkModulesNGEnabled', 'TRUE');
+        }
     }
 
     if (isInstalled("zimbra-network-modules-ng") && $newinstall) {


### PR DESCRIPTION
**Problem**: 

- If the user has chosen to install _zimbra-network-modules-ng_ then the installer should prompt the user for _zimbra-talk_ package installation and accept the input as Yes/No from the user.
- If the user has chosen not to install the _zimbra-network-modules-ng_ then  prompt the user for _zimbra-chat_ package installation and accept the input as Yes/No from the user.

**Approach and Fix**: 

**1.**  Created a function _getChatOrTalkPackage_  and used it in the _getInstallPackages_ in the `rpmconf/Install/Util/utilfunc.sh` file that will serve the above stated problem.
**2.** Added logic for checking _zimbra-chat_ package is installed or not in _findUbuntuExternalPackageDependencies()_ function
**3.** created a variable _CHAT_PACKAGES_ in `rpmconf/Install/Util/global.sh` and used for checking the existing installation contains _zimbra-chat_ or _zimbra-talk_ for display while uninstallation.

**Testing done:**

> **For testing installation**

a. If _zimbra-network-modules-ng_ is selected to be installed then _zimbra-talk_ is installed.
b. If _zimbra-network-modules-ng_ is NOT selected to be installed then _zimbra-chat_ is installed.
c.  If _zimbra-network-modules-ng_ is selected to be installed then _zimbra-talk_ is NOT selected to be installed, then it should also not install _zimbra-chat_.
d.  If _zimbra-network-modules-ng_ is NOT selected to be installed then _zimbra-chat_ is NOT selected to be installed.

> **For testing Upgrade**

a. While upgrading if _zimbra-chat_ was installed and user has selected _zimbra-network-modules-ng_ to be installed then it should remove _zimbra-chat_ and install _zimbra-talk_
b. While upgrading if _zimbra-network-modules-ng_ is only installed and neither _zimbra-talk_ nor _zimbra-chat_ is installed then it should install _zimbra-talk_.
c. While upgrading if _zimbra-network-modules-ng_ and _zimbra-talk_ are installed then _zimbra-talk_ should be installed.

> **For testing uninstallation**

a. During uninstallation it is displaying whether _zimbra-chat_ or _zimbra-talk_ was installed while checking the existing installation and it was removing the appropriate packages successfully.