### PR TITLE
Bugfix/8.8.9

### DIFF
--- a/rpmconf/Install/Util/globals.sh
+++ b/rpmconf/Install/Util/globals.sh
@@ -40,6 +40,7 @@ OPTIONAL_PACKAGES="zimbra-qatest \
 zimbra-chat \
 zimbra-drive \
 zimbra-imapd \
+zimbra-patch \
 zimbra-license-tools \
 zimbra-license-extension \
 zimbra-network-store \

--- a/rpmconf/Install/Util/globals.sh
+++ b/rpmconf/Install/Util/globals.sh
@@ -37,7 +37,6 @@ zimbra-archiving"
 SERVICES=""
 
 OPTIONAL_PACKAGES="zimbra-qatest \
-zimbra-chat \
 zimbra-drive \
 zimbra-imapd \
 zimbra-patch \
@@ -45,6 +44,9 @@ zimbra-license-tools \
 zimbra-license-extension \
 zimbra-network-store \
 zimbra-network-modules-ng"
+
+CHAT_PACKAGES="zimbra-chat \
+zimbra-talk"
 
 PACKAGE_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)/packages"
 

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -2315,7 +2315,7 @@ if [ x"$ZMTYPE_INSTALLABLE" = "xNETWORK" ]; then
 cat >> /etc/yum.repos.d/zimbra.repo <<EOF
 [zimbra-889-network]
 name=Zimbra New RPM Repository
-baseurl=https://$PACKAGE_SERVER/rpm/889-nw/$repo
+baseurl=https://$PACKAGE_SERVER/rpm/889-ne/$repo
 gpgcheck=1
 enabled=1
 EOF

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -1818,6 +1818,23 @@ removeExistingPackages() {
   done
 }
 
+removeChatIfInstalled() {
+   for i in $INSTALL_PACKAGES; do
+     if [ x$i = "xzimbra-talk" ]; then
+        echo ""
+        echo "Checking zimbra-chat already installed or not..."
+       isInstalled "zimbra-chat"
+        if [ x$PKGINSTALLED != "x" ]; then
+          echo -n "   zimbra-chat FOUND..."
+          echo ""
+          echo -n "   Removing zimbra-chat..."
+          $PACKAGERM zimbra-chat >/dev/null 2>&1
+          echo "done"
+        fi
+      fi
+    done
+}
+
 removeExistingInstall() {
   if [ $INSTALLED = "yes" ]; then
     echo ""
@@ -1864,6 +1881,7 @@ removeExistingInstall() {
     fi
     if [ "$UPGRADE" = "yes" -a "$POST87UPGRADE" = "true" -a "$FORCE_UPGRADE" != "yes" -a "$ZM_CUR_BUILD" != "$ZM_INST_BUILD" ]; then
       echo "Upgrading the remote packages"
+      removeChatIfInstalled
     else
       removeExistingPackages
     fi

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -2400,6 +2400,8 @@ getInstallPackages() {
 
     if [ $i = "zimbra-license-tools" ]; then
       response="yes"
+    elif [ $i = "zimbra-patch" ]; then
+      response="yes"
     elif [ $i = "zimbra-license-extension" ]; then
       ifStoreSelectedY
     elif [ $i = "zimbra-network-store" ]; then

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -1646,9 +1646,9 @@ saveExistingConfig() {
 findUbuntuExternalPackageDependencies() {
   # Handle external packages like logwatch, mailutils depends on zimbra-mta.
   if [ $INSTALLED = "yes" -a $ISUBUNTU = "true" ]; then
-    isInstalled "zimbra-talk"
+    isInstalled "zimbra-chat"
     if [ x$PKGINSTALLED != "x" ]; then
-      INSTALLED_PACKAGES="$INSTALLED_PACKAGES zimbra-talk"
+      INSTALLED_PACKAGES="$INSTALLED_PACKAGES zimbra-chat"
     fi
     $PACKAGERMSIMULATE $INSTALLED_PACKAGES > /dev/null 2>&1
     if [ $? -ne 0 ]; then
@@ -2303,6 +2303,25 @@ fi
   fi
 }
 
+getChatOrTalkPackage() {
+
+ if [ $response = "yes" ]; then
+    askInstallPkgYN "Install zimbra-talk" "yes" "Y" "N"
+    if [ $response = "yes" ]; then
+       INSTALL_PACKAGES="$INSTALL_PACKAGES zimbra-talk"
+    elif [ $response = "no" ]; then
+       response="yes"
+    fi
+  elif [ $response = "no" ]; then
+    askInstallPkgYN "Install zimbra-chat" "yes" "Y" "N"
+    if [ $response = "yes" ]; then
+       INSTALL_PACKAGES="$INSTALL_PACKAGES zimbra-chat"
+       response="no"
+    fi
+ fi
+
+}
+
 getInstallPackages() {
 
   echo ""
@@ -2377,12 +2396,11 @@ getInstallPackages() {
     elif [ $UPGRADE = "yes" ]; then
       if [ $i = "zimbra-archiving" ]; then
         askInstallPkgYN "Install $i" "yes" "N" "N"
-      elif [ $i = "zimbra-chat" ]; then
-        askInstallPkgYN "Install $i" "yes" "N" "N"
       elif [ $i = "zimbra-drive" ]; then
         askInstallPkgYN "Install $i" "yes" "N" "N"
       elif [ $i = "zimbra-network-modules-ng" ]; then
         askInstallPkgYN "Install $i" "yes" "N" "N"
+        getChatOrTalkPackage
       elif [ $i = "zimbra-imapd" ]; then
         askInstallPkgYN "Install $i (BETA - for evaluation only)" "no" "N" "N"
       else
@@ -2393,12 +2411,11 @@ getInstallPackages() {
         askInstallPkgYN "Install $i" "yes" "N" "N"
       elif [ $i = "zimbra-convertd" ]; then
         askInstallPkgYN "Install $i" "no" "Y" "N"
-      elif [ $i = "zimbra-chat" ]; then
-        askInstallPkgYN "Install $i" "yes" "Y" "N"
       elif [ $i = "zimbra-drive" ]; then
         askInstallPkgYN "Install $i" "yes" "Y" "N"
       elif [ $i = "zimbra-network-modules-ng" ]; then
         askInstallPkgYN "Install $i" "yes" "Y" "N"
+        getChatOrTalkPackage
       elif [ $i = "zimbra-imapd" ]; then
         askInstallPkgYN "Install $i (BETA - for evaluation only)" "no" "N" "N"
       elif [ $i = "zimbra-dnscache" ]; then
@@ -2709,7 +2726,7 @@ getPlatformVars() {
     REPOINST='apt-get install -y'
     PACKAGEDOWNLOAD='apt-get --download-only install -y --force-yes'
     REPORM='apt-get -y --purge purge'
-    PACKAGEINST='dpkg -i --auto-deconfigure'
+    PACKAGEINST='dpkg -i'
     PACKAGERM='dpkg --purge'
     PACKAGERMSIMULATE='dpkg --purge --dry-run'
     PACKAGEQUERY='dpkg -s'

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -1743,6 +1743,13 @@ removeExistingPackages() {
         echo "done"
       fi
 
+      isInstalled "zimbra-patch"
+      if [ x$PKGINSTALLED != "x" ]; then
+        echo -n "   zimbra-patch..."
+        $PACKAGERM zimbra-patch >/dev/null 2>&1
+        echo "done"
+      fi
+
       isInstalled "zimbra-network-modules-ng"
       if [ x$PKGINSTALLED != "x" ]; then
         echo -n "   zimbra-network-modules-ng..."

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -2785,7 +2785,7 @@ getPlatformVars() {
     REPOINST='apt-get install -y'
     PACKAGEDOWNLOAD='apt-get --download-only install -y --force-yes'
     REPORM='apt-get -y --purge purge'
-    PACKAGEINST='dpkg -i'
+    PACKAGEINST='dpkg -i --auto-deconfigure'
     PACKAGERM='dpkg --purge'
     PACKAGERMSIMULATE='dpkg --purge --dry-run'
     PACKAGEQUERY='dpkg -s'

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -1650,10 +1650,6 @@ findUbuntuExternalPackageDependencies() {
     if [ x$PKGINSTALLED != "x" ]; then
       INSTALLED_PACKAGES="$INSTALLED_PACKAGES zimbra-talk"
     fi
-    isInstalled "zimbra-patch"
-    if [ x$PKGINSTALLED != "x" ]; then
-      INSTALLED_PACKAGES="$INSTALLED_PACKAGES zimbra-patch"
-    fi
     $PACKAGERMSIMULATE $INSTALLED_PACKAGES > /dev/null 2>&1
     if [ $? -ne 0 ]; then
       EXTPACKAGESTMP=`$PACKAGERMSIMULATE $INSTALLED_PACKAGES 2>&1 | grep " depends on " | cut -d' ' -f2 | grep -v zimbra`

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -1671,7 +1671,7 @@ findUbuntuExternalPackageDependencies() {
         removeErrorMessage
       else
         echo "External package dependencies found: $EXTPACKAGES"
-        $PACKAGERMSIMULATE $INSTALLED_PACKAGES $EXTPACKAGES
+        $PACKAGERMSIMULATE $INSTALLED_PACKAGES $EXTPACKAGES >> $LOGFILE 2>&1
         if [ $? -eq 0 ]; then
           while :; do
             askYN "$EXTPACKAGES package[s] will be removed. Continue?" "N"

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -2347,6 +2347,10 @@ getChatOrTalkPackage() {
        response="no"
     fi
  fi
+<<<<<<< HEAD
+=======
+
+>>>>>>> Added check if NG is installed then install zimbra-talk otherwise install zimbra-chat
 }
 
 getInstallPackages() {
@@ -2428,13 +2432,15 @@ getInstallPackages() {
     elif [ $UPGRADE = "yes" ]; then
       if [ $i = "zimbra-archiving" ]; then
         askInstallPkgYN "Install $i" "yes" "N" "N"
-      elif [ $i = "zimbra-chat" ]; then
-        askInstallPkgYN "Install $i" "yes" "N" "N"
       elif [ $i = "zimbra-drive" ]; then
         askInstallPkgYN "Install $i" "yes" "N" "N"
       elif [ $i = "zimbra-network-modules-ng" ]; then
         askInstallPkgYN "Install $i" "yes" "N" "N"
+<<<<<<< HEAD
 	getChatOrTalkPackage
+=======
+        getChatOrTalkPackage
+>>>>>>> Added check if NG is installed then install zimbra-talk otherwise install zimbra-chat
       elif [ $i = "zimbra-imapd" ]; then
         askInstallPkgYN "Install $i (BETA - for evaluation only)" "no" "N" "N"
       else
@@ -2445,13 +2451,15 @@ getInstallPackages() {
         askInstallPkgYN "Install $i" "yes" "N" "N"
       elif [ $i = "zimbra-convertd" ]; then
         askInstallPkgYN "Install $i" "no" "Y" "N"
-      elif [ $i = "zimbra-chat" ]; then
-        askInstallPkgYN "Install $i" "yes" "Y" "N"
       elif [ $i = "zimbra-drive" ]; then
         askInstallPkgYN "Install $i" "yes" "Y" "N"
       elif [ $i = "zimbra-network-modules-ng" ]; then
         askInstallPkgYN "Install $i" "yes" "Y" "N"
+<<<<<<< HEAD
 	getChatOrTalkPackage
+=======
+        getChatOrTalkPackage
+>>>>>>> Added check if NG is installed then install zimbra-talk otherwise install zimbra-chat
       elif [ $i = "zimbra-imapd" ]; then
         askInstallPkgYN "Install $i (BETA - for evaluation only)" "no" "N" "N"
       elif [ $i = "zimbra-dnscache" ]; then
@@ -2762,7 +2770,7 @@ getPlatformVars() {
     REPOINST='apt-get install -y'
     PACKAGEDOWNLOAD='apt-get --download-only install -y --force-yes'
     REPORM='apt-get -y --purge purge'
-    PACKAGEINST='dpkg -i --auto-deconfigure'
+    PACKAGEINST='dpkg -i'
     PACKAGERM='dpkg --purge'
     PACKAGERMSIMULATE='dpkg --purge --dry-run'
     PACKAGEQUERY='dpkg -s'

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -679,6 +679,8 @@ checkExistingInstall() {
     if [ x$PKGINSTALLED != "x" ]; then
       echo "    $i...FOUND $PKGINSTALLED"
       INSTALLED_PACKAGES="$INSTALLED_PACKAGES $i"
+    else
+      echo "    $i...NOT FOUND"
     fi
   done
 
@@ -2347,13 +2349,6 @@ getChatOrTalkPackage() {
        response="no"
     fi
  fi
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-
->>>>>>> Added check if NG is installed then install zimbra-talk otherwise install zimbra-chat
-=======
->>>>>>> added chat and talk packages as CHAT_PACKAGES to show while uninstalling and added zimbra-talk installation check while uninstalling
 }
 
 getInstallPackages() {
@@ -2371,6 +2366,10 @@ getInstallPackages() {
   LOGGER_SELECTED="no"
   STORE_SELECTED="no"
   MTA_SELECTED="no"
+
+  if [ x"$ZMTYPE_INSTALLABLE" = "xFOSS" ]; then
+     AVAILABLE_PACKAGES="$AVAILABLE_PACKAGES zimbra-chat"
+  fi
 
   for i in $AVAILABLE_PACKAGES; do
     if [ $i = "zimbra-core" ]; then
@@ -2438,8 +2437,11 @@ getInstallPackages() {
       elif [ $i = "zimbra-chat" ]; then
         askInstallPkgYN "Install $i" "yes" "N" "N"
       elif [ $i = "zimbra-drive" ]; then
-        askInstallPkgYN "Install $i" "yes" "N" "N"
+	if [ $STORE_SELECTED = "yes" ]; then
+          askInstallPkgYN "Install $i" "yes" "N" "N"
+	fi
       elif [ $i = "zimbra-network-modules-ng" ]; then
+<<<<<<< HEAD
         askInstallPkgYN "Install $i" "yes" "N" "N"
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -2450,6 +2452,12 @@ getInstallPackages() {
 =======
 	getChatOrTalkPackage
 >>>>>>> added chat and talk packages as CHAT_PACKAGES to show while uninstalling and added zimbra-talk installation check while uninstalling
+=======
+	if [ $STORE_SELECTED = "yes" ]; then
+          askInstallPkgYN "Install $i" "yes" "N" "N"
+	  getChatOrTalkPackage
+	fi
+>>>>>>> Fixed the missing chat prompt for FOSS.
       elif [ $i = "zimbra-imapd" ]; then
         askInstallPkgYN "Install $i (BETA - for evaluation only)" "no" "N" "N"
       else
@@ -2463,8 +2471,11 @@ getInstallPackages() {
       elif [ $i = "zimbra-chat" ]; then
         askInstallPkgYN "Install $i" "yes" "Y" "N"
       elif [ $i = "zimbra-drive" ]; then
-        askInstallPkgYN "Install $i" "yes" "Y" "N"
+	if [ $STORE_SELECTED = "yes" ]; then
+          askInstallPkgYN "Install $i" "yes" "Y" "N"
+	fi
       elif [ $i = "zimbra-network-modules-ng" ]; then
+<<<<<<< HEAD
         askInstallPkgYN "Install $i" "yes" "Y" "N"
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -2475,6 +2486,12 @@ getInstallPackages() {
 =======
 	getChatOrTalkPackage
 >>>>>>> added chat and talk packages as CHAT_PACKAGES to show while uninstalling and added zimbra-talk installation check while uninstalling
+=======
+	if [ $STORE_SELECTED = "yes" ]; then
+          askInstallPkgYN "Install $i" "yes" "Y" "N"
+	  getChatOrTalkPackage
+	fi
+>>>>>>> Fixed the missing chat prompt for FOSS.
       elif [ $i = "zimbra-imapd" ]; then
         askInstallPkgYN "Install $i (BETA - for evaluation only)" "no" "N" "N"
       elif [ $i = "zimbra-dnscache" ]; then

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -2744,7 +2744,7 @@ getPlatformVars() {
     REPOINST='apt-get install -y'
     PACKAGEDOWNLOAD='apt-get --download-only install -y --force-yes'
     REPORM='apt-get -y --purge purge'
-    PACKAGEINST='dpkg -i'
+    PACKAGEINST='dpkg -i --auto-deconfigure'
     PACKAGERM='dpkg --purge'
     PACKAGERMSIMULATE='dpkg --purge --dry-run'
     PACKAGEQUERY='dpkg -s'

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -1654,14 +1654,12 @@ saveExistingConfig() {
 findUbuntuExternalPackageDependencies() {
   # Handle external packages like logwatch, mailutils depends on zimbra-mta.
   if [ $INSTALLED = "yes" -a $ISUBUNTU = "true" ]; then
-    isInstalled "zimbra-talk"
-    if [ x$PKGINSTALLED != "x" ]; then
-      INSTALLED_PACKAGES="$INSTALLED_PACKAGES zimbra-talk"
-    fi
-    isInstalled "zimbra-chat"
-    if [ x$PKGINSTALLED != "x" ]; then
-      INSTALLED_PACKAGES="$INSTALLED_PACKAGES zimbra-chat"
-    fi
+    for i in $CHAT_PACKAGES; do
+      isInstalled $i
+     if [ x$PKGINSTALLED != "x" ]; then
+      INSTALLED_PACKAGES="$INSTALLED_PACKAGES $i"
+     fi
+    done
     $PACKAGERMSIMULATE $INSTALLED_PACKAGES > /dev/null 2>&1
     if [ $? -ne 0 ]; then
       EXTPACKAGESTMP=`$PACKAGERMSIMULATE $INSTALLED_PACKAGES 2>&1 | grep " depends on " | cut -d' ' -f2 | grep -v zimbra`
@@ -2361,6 +2359,9 @@ getInstallPackages() {
       echo $INSTALLED_PACKAGES | grep $i > /dev/null 2>&1
       if [ $? = 0 ]; then
         echo "    Upgrading $i"
+        if [ $i = "zimbra-network-modules-ng" ]; then
+          INSTALL_PACKAGES="$INSTALL_PACKAGES zimbra-talk"
+        fi
         if [ $i = "zimbra-mta" ]; then
           CONFLICTS="no"
           for j in $CONFLICT_PACKAGES; do

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -2427,7 +2427,7 @@ getInstallPackages() {
     if [ $i = "zimbra-license-tools" ]; then
       response="yes"
     elif [ $i = "zimbra-patch" ]; then
-      response="yes"
+      ifStoreSelectedY
     elif [ $i = "zimbra-license-extension" ]; then
       ifStoreSelectedY
     elif [ $i = "zimbra-network-store" ]; then

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -674,6 +674,14 @@ checkExistingInstall() {
     fi
   done
 
+  for i in $CHAT_PACKAGES; do
+    isInstalled $i
+    if [ x$PKGINSTALLED != "x" ]; then
+      echo "    $i...FOUND $PKGINSTALLED"
+      INSTALLED_PACKAGES="$INSTALLED_PACKAGES $i"
+    fi
+  done
+
   for i in $PACKAGES $CORE_PACKAGES; do
     echo -n "    $i..."
     isInstalled $i
@@ -1646,6 +1654,10 @@ saveExistingConfig() {
 findUbuntuExternalPackageDependencies() {
   # Handle external packages like logwatch, mailutils depends on zimbra-mta.
   if [ $INSTALLED = "yes" -a $ISUBUNTU = "true" ]; then
+    isInstalled "zimbra-talk"
+    if [ x$PKGINSTALLED != "x" ]; then
+      INSTALLED_PACKAGES="$INSTALLED_PACKAGES zimbra-talk"
+    fi
     isInstalled "zimbra-chat"
     if [ x$PKGINSTALLED != "x" ]; then
       INSTALLED_PACKAGES="$INSTALLED_PACKAGES zimbra-chat"
@@ -1661,7 +1673,7 @@ findUbuntuExternalPackageDependencies() {
         removeErrorMessage
       else
         echo "External package dependencies found: $EXTPACKAGES"
-        $PACKAGERMSIMULATE $INSTALLED_PACKAGES $EXTPACKAGES >> $LOGFILE 2>&1
+        $PACKAGERMSIMULATE $INSTALLED_PACKAGES $EXTPACKAGES
         if [ $? -eq 0 ]; then
           while :; do
             askYN "$EXTPACKAGES package[s] will be removed. Continue?" "N"
@@ -2319,7 +2331,6 @@ getChatOrTalkPackage() {
        response="no"
     fi
  fi
-
 }
 
 getInstallPackages() {
@@ -2396,11 +2407,13 @@ getInstallPackages() {
     elif [ $UPGRADE = "yes" ]; then
       if [ $i = "zimbra-archiving" ]; then
         askInstallPkgYN "Install $i" "yes" "N" "N"
+      elif [ $i = "zimbra-chat" ]; then
+        askInstallPkgYN "Install $i" "yes" "N" "N"
       elif [ $i = "zimbra-drive" ]; then
         askInstallPkgYN "Install $i" "yes" "N" "N"
       elif [ $i = "zimbra-network-modules-ng" ]; then
         askInstallPkgYN "Install $i" "yes" "N" "N"
-        getChatOrTalkPackage
+	getChatOrTalkPackage
       elif [ $i = "zimbra-imapd" ]; then
         askInstallPkgYN "Install $i (BETA - for evaluation only)" "no" "N" "N"
       else
@@ -2411,11 +2424,13 @@ getInstallPackages() {
         askInstallPkgYN "Install $i" "yes" "N" "N"
       elif [ $i = "zimbra-convertd" ]; then
         askInstallPkgYN "Install $i" "no" "Y" "N"
+      elif [ $i = "zimbra-chat" ]; then
+        askInstallPkgYN "Install $i" "yes" "Y" "N"
       elif [ $i = "zimbra-drive" ]; then
         askInstallPkgYN "Install $i" "yes" "Y" "N"
       elif [ $i = "zimbra-network-modules-ng" ]; then
         askInstallPkgYN "Install $i" "yes" "Y" "N"
-        getChatOrTalkPackage
+	getChatOrTalkPackage
       elif [ $i = "zimbra-imapd" ]; then
         askInstallPkgYN "Install $i (BETA - for evaluation only)" "no" "N" "N"
       elif [ $i = "zimbra-dnscache" ]; then

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -1673,7 +1673,7 @@ findUbuntuExternalPackageDependencies() {
         removeErrorMessage
       else
         echo "External package dependencies found: $EXTPACKAGES"
-        $PACKAGERMSIMULATE $INSTALLED_PACKAGES $EXTPACKAGES
+        $PACKAGERMSIMULATE $INSTALLED_PACKAGES $EXTPACKAGES >> $LOGFILE 2>&1
         if [ $? -eq 0 ]; then
           while :; do
             askYN "$EXTPACKAGES package[s] will be removed. Continue?" "N"

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -1671,7 +1671,7 @@ findUbuntuExternalPackageDependencies() {
         removeErrorMessage
       else
         echo "External package dependencies found: $EXTPACKAGES"
-        $PACKAGERMSIMULATE $INSTALLED_PACKAGES $EXTPACKAGES >> $LOGFILE 2>&1
+        $PACKAGERMSIMULATE $INSTALLED_PACKAGES $EXTPACKAGES
         if [ $? -eq 0 ]; then
           while :; do
             askYN "$EXTPACKAGES package[s] will be removed. Continue?" "N"
@@ -2348,9 +2348,12 @@ getChatOrTalkPackage() {
     fi
  fi
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 
 >>>>>>> Added check if NG is installed then install zimbra-talk otherwise install zimbra-chat
+=======
+>>>>>>> added chat and talk packages as CHAT_PACKAGES to show while uninstalling and added zimbra-talk installation check while uninstalling
 }
 
 getInstallPackages() {
@@ -2432,15 +2435,21 @@ getInstallPackages() {
     elif [ $UPGRADE = "yes" ]; then
       if [ $i = "zimbra-archiving" ]; then
         askInstallPkgYN "Install $i" "yes" "N" "N"
+      elif [ $i = "zimbra-chat" ]; then
+        askInstallPkgYN "Install $i" "yes" "N" "N"
       elif [ $i = "zimbra-drive" ]; then
         askInstallPkgYN "Install $i" "yes" "N" "N"
       elif [ $i = "zimbra-network-modules-ng" ]; then
         askInstallPkgYN "Install $i" "yes" "N" "N"
 <<<<<<< HEAD
+<<<<<<< HEAD
 	getChatOrTalkPackage
 =======
         getChatOrTalkPackage
 >>>>>>> Added check if NG is installed then install zimbra-talk otherwise install zimbra-chat
+=======
+	getChatOrTalkPackage
+>>>>>>> added chat and talk packages as CHAT_PACKAGES to show while uninstalling and added zimbra-talk installation check while uninstalling
       elif [ $i = "zimbra-imapd" ]; then
         askInstallPkgYN "Install $i (BETA - for evaluation only)" "no" "N" "N"
       else
@@ -2451,15 +2460,21 @@ getInstallPackages() {
         askInstallPkgYN "Install $i" "yes" "N" "N"
       elif [ $i = "zimbra-convertd" ]; then
         askInstallPkgYN "Install $i" "no" "Y" "N"
+      elif [ $i = "zimbra-chat" ]; then
+        askInstallPkgYN "Install $i" "yes" "Y" "N"
       elif [ $i = "zimbra-drive" ]; then
         askInstallPkgYN "Install $i" "yes" "Y" "N"
       elif [ $i = "zimbra-network-modules-ng" ]; then
         askInstallPkgYN "Install $i" "yes" "Y" "N"
 <<<<<<< HEAD
+<<<<<<< HEAD
 	getChatOrTalkPackage
 =======
         getChatOrTalkPackage
 >>>>>>> Added check if NG is installed then install zimbra-talk otherwise install zimbra-chat
+=======
+	getChatOrTalkPackage
+>>>>>>> added chat and talk packages as CHAT_PACKAGES to show while uninstalling and added zimbra-talk installation check while uninstalling
       elif [ $i = "zimbra-imapd" ]; then
         askInstallPkgYN "Install $i (BETA - for evaluation only)" "no" "N" "N"
       elif [ $i = "zimbra-dnscache" ]; then

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -1650,6 +1650,10 @@ findUbuntuExternalPackageDependencies() {
     if [ x$PKGINSTALLED != "x" ]; then
       INSTALLED_PACKAGES="$INSTALLED_PACKAGES zimbra-talk"
     fi
+    isInstalled "zimbra-patch"
+    if [ x$PKGINSTALLED != "x" ]; then
+      INSTALLED_PACKAGES="$INSTALLED_PACKAGES zimbra-patch"
+    fi
     $PACKAGERMSIMULATE $INSTALLED_PACKAGES > /dev/null 2>&1
     if [ $? -ne 0 ]; then
       EXTPACKAGESTMP=`$PACKAGERMSIMULATE $INSTALLED_PACKAGES 2>&1 | grep " depends on " | cut -d' ' -f2 | grep -v zimbra`

--- a/rpmconf/Install/zmsetup.pl
+++ b/rpmconf/Install/zmsetup.pl
@@ -7191,10 +7191,10 @@ sub applyConfig {
       }
     }
 
-    if (!isInstalled("zimbra-network-modules-ng")) {
-      setLdapServerConfig($config{HOSTNAME}, 'zimbraNetworkModulesNGEnabled', 'FALSE');
-    } else {
-      setLdapServerConfig($config{HOSTNAME}, 'zimbraNetworkModulesNGEnabled', 'TRUE');
+    if (isInstalled("zimbra-network-modules-ng")) {
+       if ($prevVersionMajor <= 8 && $prevVersionMinor <= 7) {
+        setLdapServerConfig($config{HOSTNAME}, 'zimbraNetworkModulesNGEnabled', 'TRUE');
+        }
     }
 
     if (isInstalled("zimbra-network-modules-ng") && $newinstall) {


### PR DESCRIPTION
**[Bugfix#1]**
 zimbraNetworkModulesNGEnabled was always set to 'TRUE' by the zmsetup.pl

**Problem:** While upgrading to new version after 8.7.x _zimbraNetworkModulesNGEnabled_ was always set to 'TRUE' by the _zmsetup.pl_ script.

**Approach and Fix:** In the zmsetup.pl script while upgrading if the previous version is <= 8.7.x then _zimbraNetworkModulesNGEnabled_ is set to 'TRUE'

**Testing done:** 
1. Installed fresh 8.7.11_GA_1854 and there was no attribute present as  _zimbraNetworkModulesNGEnabled_
2. Upgraded from 8.7.11_GA_1854 to 8.8.8_GA_2009 _zimbraNetworkModulesNGEnabled_ was set to 'TRUE'
3. Manually set _zimbraNetworkModulesNGEnabled_ to 'FALSE' on 8.8.8_GA_2009
    Re-ran the _zmsetup.pl_ _zimbraNetworkModulesNGEnabled_retained to 'FALSE'
4. Upgraded from 8.8.8_GA_2009 to 8.8.9_GA_1731 _zimbraNetworkModulesNGEnabled_ remained 'FALSE'
5. Manually set _zimbraNetworkModulesNGEnabled_ to 'TRUE' on 8.8.9_GA_1731
    Re-ran the _zmsetup.pl_ _zimbraNetworkModulesNGEnabled_retained to 'TRUE'

----------------------------------------------------------------------------------------------------
**[Bugfix#2]**
**Problem:** 
**1.** Add zimbra-patch package for installation and prompt the user for its Yes/No for its installation.
**2.** If zimbra-patch was installed from the repos then uninstallation was failing.

**Approach and Fix:**  zimbra-patch was added to _OPTIONAL_PACKAGES_ in _global.sh_  and added procedure for uninstallation of zimbra-patch in _utilfunc.sh_ file if zimbra-patch is already installed.

**Testing done:** 
1. For testing _uninstallation_
a. Manually installed zimbra-patch and ran `intstall.sh -u` and the patch was uninstallation was successful as compared to prior it was failing at this step.
b. If the package was installed automatically by adding it to  _OPTIONAL_PACKAGES_ in _global.sh_ uninstallation was successful.
 
2. For testing _installation_
a. Installation was successful with zimbra-patch by adding it to  _OPTIONAL_PACKAGES_ in _global.sh_
b. Tested for both the case of Yes and No prompt while installation.

----------------------------------------------------------------------------------------------------

**[Bugfix#3]**
**Problem**: 

- If the user has chosen to install _zimbra-network-modules-ng_ then the installer should prompt the user for _zimbra-talk_ package installation and accept the input as Yes/No from the user.
- If the user has chosen not to install the _zimbra-network-modules-ng_ then  prompt the user for _zimbra-chat_ package installation and accept the input as Yes/No from the user.

**Approach and Fix**: 

**1.**  Created a function _getChatOrTalkPackage_  and used it in the _getInstallPackages_ in the `rpmconf/Install/Util/utilfunc.sh` file that will serve the above stated problem.
**2.** Added logic for checking _zimbra-chat_ package is installed or not in _findUbuntuExternalPackageDependencies()_ function
**3.** created a variable _CHAT_PACKAGES_ in `rpmconf/Install/Util/global.sh` and used for checking the existing installation contains _zimbra-chat_ or _zimbra-talk_ for display while uninstallation.

**Testing done:**

> **For testing installation**

a. If _zimbra-network-modules-ng_ is selected to be installed then _zimbra-talk_ is installed.
b. If _zimbra-network-modules-ng_ is NOT selected to be installed then _zimbra-chat_ is installed.
c.  If _zimbra-network-modules-ng_ is selected to be installed then _zimbra-talk_ is NOT selected to be installed, then it should also not install _zimbra-chat_.
d.  If _zimbra-network-modules-ng_ is NOT selected to be installed then _zimbra-chat_ is NOT selected to be installed.

> **For testing Upgrade**

a. While upgrading if _zimbra-chat_ was installed and user has selected _zimbra-network-modules-ng_ to be installed then it should remove _zimbra-chat_ and install _zimbra-talk_
b. While upgrading if _zimbra-network-modules-ng_ is only installed and neither _zimbra-talk_ nor _zimbra-chat_ is installed then it should install _zimbra-talk_.
c. While upgrading if _zimbra-network-modules-ng_ and _zimbra-talk_ are installed then _zimbra-talk_ should be installed.
d. Upgraded from 8.8.9 FOSS to 8.8.9 Network Edition and it has uninstalled _zimbra-chat_ while switching to Network Edition and installed _zimbra-talk_ (as _zimbra-talk_ was selected to install from the prompt after selecting the _zimbra-network-modules-ng_  module)

> **For testing uninstallation**

a. During uninstallation, it is displaying whether _zimbra-chat_ or _zimbra-talk_ was installed while checking the existing installation and it was removing the appropriate packages successfully.