### PR TITLE
Bugfix/8.8.9

### DIFF
--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -2383,7 +2383,10 @@ getInstallPackages() {
       if [ $? = 0 ]; then
         echo "    Upgrading $i"
         if [ $i = "zimbra-network-modules-ng" ]; then
-          INSTALL_PACKAGES="$INSTALL_PACKAGES zimbra-talk"
+            askInstallPkgYN "Install zimbra-talk" "yes" "Y" "N"
+            if [ $response = "yes" ]; then
+                INSTALL_PACKAGES="$INSTALL_PACKAGES zimbra-talk"
+            fi
         fi
         if [ $i = "zimbra-mta" ]; then
           CONFLICTS="no"

--- a/rpmconf/Install/zmsetup.pl
+++ b/rpmconf/Install/zmsetup.pl
@@ -6496,7 +6496,7 @@ sub zimletCleanup {
     return 1;
   } else {
     detail("ldap bind done for $ldap_dn");
-    $result = $ldap->search(base => $ldap_base, scope => 'one', filter => "(|(cn=convertd)(cn=hsm)(cn=hotbackup)(cn=zimbra_cert_manager)(cn=com_zimbra_search)(cn=zimbra_xmbxsearch)(cn=com_zimbra_domainadmin)(cn=com_zimbra_tinymce)(cn=com_zimbra_tasksreminder)(cn=com_zimbra_linkedin)(cn=com_zimbra_social)(cn=com_zimbra_dnd) (cn=com_zextras_chat_open))", attrs => ['cn']);
+    $result = $ldap->search(base => $ldap_base, scope => 'one', filter => "(|(cn=convertd)(cn=hsm)(cn=hotbackup)(cn=zimbra_cert_manager)(cn=com_zimbra_search)(cn=zimbra_xmbxsearch)(cn=com_zimbra_domainadmin)(cn=com_zimbra_tinymce)(cn=com_zimbra_tasksreminder)(cn=com_zimbra_linkedin)(cn=com_zimbra_social)(cn=com_zimbra_dnd)(cn=com_zextras_chat_open))", attrs => ['cn']);
     return $result if ($result->code());
     detail("Processing ldap search results");
     foreach my $entry ($result->all_entries) {

--- a/rpmconf/Install/zmsetup.pl
+++ b/rpmconf/Install/zmsetup.pl
@@ -6496,7 +6496,7 @@ sub zimletCleanup {
     return 1;
   } else {
     detail("ldap bind done for $ldap_dn");
-    $result = $ldap->search(base => $ldap_base, scope => 'one', filter => "(|(cn=convertd)(cn=hsm)(cn=hotbackup)(cn=zimbra_cert_manager)(cn=com_zimbra_search)(cn=zimbra_xmbxsearch)(cn=com_zimbra_domainadmin)(cn=com_zimbra_tinymce)(cn=com_zimbra_tasksreminder)(cn=com_zimbra_linkedin)(cn=com_zimbra_social)(cn=com_zimbra_dnd))", attrs => ['cn']);
+    $result = $ldap->search(base => $ldap_base, scope => 'one', filter => "(|(cn=convertd)(cn=hsm)(cn=hotbackup)(cn=zimbra_cert_manager)(cn=com_zimbra_search)(cn=zimbra_xmbxsearch)(cn=com_zimbra_domainadmin)(cn=com_zimbra_tinymce)(cn=com_zimbra_tasksreminder)(cn=com_zimbra_linkedin)(cn=com_zimbra_social)(cn=com_zimbra_dnd) (cn=com_zextras_chat_open))", attrs => ['cn']);
     return $result if ($result->code());
     detail("Processing ldap search results");
     foreach my $entry ($result->all_entries) {

--- a/rpmconf/Install/zmsetup.pl
+++ b/rpmconf/Install/zmsetup.pl
@@ -7196,6 +7196,9 @@ sub applyConfig {
         setLdapServerConfig($config{HOSTNAME}, 'zimbraNetworkModulesNGEnabled', 'TRUE');
         }
     }
+    else {
+      setLdapServerConfig($config{HOSTNAME}, 'zimbraNetworkModulesNGEnabled', 'FALSE');
+    }
 
     if (isInstalled("zimbra-network-modules-ng") && $newinstall) {
       main::progress("Enabling zimbra network NG modules features.\n");


### PR DESCRIPTION
Fix for ZCS-5454, ZCS-5456 and ZCS-5459

1. Bugfix: **ZCS-5454** - Fixed undeployment of chat zimlet completely.

2.  Bugfix: **ZCS-5456** - Fixed the bug of installing _zimbra-talk_ directly while upgrading if NG module was selected Yes. Added prompt for installing _zimbra-talk_ while upgrading.

3. Bugfix: **ZCS-5459** - Handled condition if NG module is not installed then set LDAP attribute _zimbraNetworkModulesNGEnabled_ as false.