### PR TITLE
Bug 109010: Ignore dpkg hold on upgrade

### DIFF
--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -2779,12 +2779,12 @@ getPlatformVars() {
   if [ $? = 0 ]; then
     ISUBUNTU=true
     checkUbuntuRelease
-    REPOINST='apt-get install -y'
-    PACKAGEDOWNLOAD='apt-get --download-only install -y --force-yes'
-    REPORM='apt-get -y --purge purge'
-    PACKAGEINST='dpkg -i --auto-deconfigure'
-    PACKAGERM='dpkg --purge'
-    PACKAGERMSIMULATE='dpkg --purge --dry-run'
+    REPOINST='apt-get install --ignore-hold --yes'
+    PACKAGEDOWNLOAD='apt-get install --ignore-hold --yes --force-yes --download-only'
+    REPORM='apt-get remove --purge --ignore-hold --yes'
+    PACKAGEINST='dpkg --install --force-hold --auto-deconfigure'
+    PACKAGERM='dpkg --purge --force-hold'
+    PACKAGERMSIMULATE='dpkg --purge --force-hold --dry-run'
     PACKAGEQUERY='dpkg -s'
     PACKAGEEXT='deb'
     PACKAGEVERSION="dpkg-query -W -f \${Version}"


### PR DESCRIPTION
This is a suggested change to improve the handling of upgrades on systems where the Zimbra packages are pinned/marked for hold.

To avoid accidental updates of Zimbra packages together with regular system updates, these can be marked for hold via the command
```apt-mark hold 'zimbra-*'```

Zimbra updates can be installed via an explicit
```apt-get upgrade --ignore-hold --only-upgrade 'zimbra-*'```

Upgrading using the installer will fail though unless an explicit
```apt-mark unhold 'zimbra-*'```
was executed beforehand.

This patch makes the installer ignore the hold states so updates go more smoothly.

This only affects Debian/Ubuntu for Red Hat/CentOS a similar logic would have to be implemented.

I tested this on Ubuntu 16.04 and via the manpages I verified that the added options `--ignore-hold` for `apt-get` and `--force-hold` for `dpkg` are available on Ubuntu 14.04 as well.