### PR TITLE
Avoid shipping .git dirs for zm-help zm-downloads

### DIFF
--- a/instructions/bundling-scripts/zimbra-store.sh
+++ b/instructions/bundling-scripts/zimbra-store.sh
@@ -146,7 +146,9 @@ main()
     fi
 
     echo "\t\t***** help content *****" >> ${buildLogFile}
-    cp -rf ${repoDir}/zm-help/. ${repoDir}/zm-build/${currentPackage}/opt/zimbra/jetty_base/webapps/zimbra/help
+    helpDir="${repoDir}/zm-build/${currentPackage}/opt/zimbra/jetty_base/webapps/zimbra/help"
+    mkdir -p "${helpDir}"
+    cp -rf ${repoDir}/zm-help/* "${helpDir}"
 
     echo "\t\t***** portals example content *****" >> ${buildLogFile}
     mkdir -p ${repoDir}/zm-build/${currentPackage}/opt/zimbra/jetty_base/webapps/zimbra/portals/example
@@ -158,7 +160,7 @@ main()
     echo "\t\t***** downloads content *****" >> ${buildLogFile}
     downloadsDir=${repoDir}/zm-build/${currentPackage}/opt/zimbra/jetty_base/webapps/zimbra/downloads
     mkdir -p ${downloadsDir}
-    cp -rf ${repoDir}/zm-downloads/. ${downloadsDir}
+    cp -rf ${repoDir}/zm-downloads/* ${downloadsDir}
 
     if [ "${buildType}" == "NETWORK" ]
     then


### PR DESCRIPTION
.git directories belonging to the zm-help and zm-downloads repositories currently end up in the builds and in the final packages.
This fix should prevent dotfiles from being copied over to the build directory