### PR TITLE
Bugfix/zcs 6769

### DIFF
--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -2568,7 +2568,7 @@ getInstallPackages() {
 installJdk11()  {
 	echo "Installing: JDK 11"
   wget -O /tmp/openjdk-11.0.2_linux-x64_bin.tar.gz https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz
-  sudo tar xfvz /tmp/openjdk-11.0.2_linux-x64_bin.tar.gz --directory /usr/lib/jvm
+  sudo tar xfz /tmp/openjdk-11.0.2_linux-x64_bin.tar.gz --directory /usr/lib/jvm
   rm -f /tmp/openjdk-11.0.2_linux-x64_bin.tar.gz
   chmod a+rwx /usr/lib/jvm/jdk-11.0.2/lib/security/cacerts 
   unlink /opt/zimbra/common/lib/jvm/java

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -1576,7 +1576,7 @@ saveExistingConfig() {
 
   if [ -x "/opt/zimbra/bin/zmlocalconfig" ]; then
     runAsZimbra "zmlocalconfig -e zimbra_java_home=/opt/zimbra/common/lib/jvm/java"
-    runAsZimbra "zmlocalconfig -e mailboxd_truststore=/opt/zimbra/common/lib/jvm/java/lib/security/cacerts"
+    runAsZimbra "zmlocalconfig -e mailboxd_truststore=/opt/zimbra/common/lib/jvm/java/jre/lib/security/cacerts"
   fi
   if [ ! -d "$SAVEDIR" ]; then
     mkdir -p $SAVEDIR
@@ -1600,10 +1600,10 @@ saveExistingConfig() {
   if [ -f "/opt/zimbra/conf/localconfig.xml" ]; then
     cp -f /opt/zimbra/conf/localconfig.xml $SAVEDIR/localconfig.xml
   fi
-  if [ -f "/opt/zimbra/common/lib/jvm/java/lib/security/cacerts" ]; then
-    cp -f /opt/zimbra/common/lib/jvm/java/lib/security/cacerts $SAVEDIR
-  elif [ -f "/opt/zimbra/java/lib/security/cacerts" ]; then
-    cp -f /opt/zimbra/java/lib/security/cacerts $SAVEDIR
+  if [ -f "/opt/zimbra/common/lib/jvm/java/jre/lib/security/cacerts" ]; then
+    cp -f /opt/zimbra/common/lib/jvm/java/jre/lib/security/cacerts $SAVEDIR
+  elif [ -f "/opt/zimbra/java/jre/lib/security/cacerts" ]; then
+    cp -f /opt/zimbra/java/jre/lib/security/cacerts $SAVEDIR
   fi
   if [ -f "/opt/zimbra/jetty/etc/keystore" ]; then
     cp -f /opt/zimbra/jetty/etc/keystore $SAVEDIR
@@ -2564,6 +2564,18 @@ getInstallPackages() {
     echo "    $i"
   done
 }
+
+installJdk11()  {
+	echo "Installing: JDK 11"
+  wget -O /tmp/openjdk-11.0.2_linux-x64_bin.tar.gz https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz
+  sudo tar xfvz /tmp/openjdk-11.0.2_linux-x64_bin.tar.gz --directory /usr/lib/jvm
+  rm -f /tmp/openjdk-11.0.2_linux-x64_bin.tar.gz
+  unlink /opt/zimbra/common/lib/jvm/java
+  ln -s /usr/lib/jvm/jdk-11.0.2/ /opt/zimbra/common/lib/jvm/java
+
+}
+
+
 
 deleteWebApp() {
   WEBAPPNAME=$1

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -991,7 +991,7 @@ verifyLicenseActivationServer() {
     elif [ ${ZM_CUR_MAJOR} -gt "7" ]; then
       /opt/zimbra/bin/zmlicense --ping > /dev/null 2>&1
     else
-      /opt/zimbra/java/bin/java -XX:ErrorFile=/opt/zimbra/log -client -Xmx256m -Dzimbra.home=/opt/zimbra -Djava.library.path=/opt/zimbra/lib -Djava.ext.dirs=/opt/zimbra/java/jre/lib/ext:/opt/zimbra/lib/jars -classpath ./lib/jars/zimbra-license-tools.jar com.zimbra.cs.license.LicenseCLI --ping > /dev/null 2>&1
+      /opt/zimbra/java/bin/java -XX:ErrorFile=/opt/zimbra/log -client -Xmx256m -Dzimbra.home=/opt/zimbra -Djava.library.path=/opt/zimbra/lib  -classpath ./lib/jars/zimbra-license-tools.jar com.zimbra.cs.license.LicenseCLI --ping > /dev/null 2>&1
     fi
     if [ $? != 0 ]; then
       activationWarning
@@ -1576,7 +1576,7 @@ saveExistingConfig() {
 
   if [ -x "/opt/zimbra/bin/zmlocalconfig" ]; then
     runAsZimbra "zmlocalconfig -e zimbra_java_home=/opt/zimbra/common/lib/jvm/java"
-    runAsZimbra "zmlocalconfig -e mailboxd_truststore=/opt/zimbra/common/lib/jvm/java/jre/lib/security/cacerts"
+    runAsZimbra "zmlocalconfig -e mailboxd_truststore=/opt/zimbra/common/lib/jvm/java/lib/security/cacerts"
   fi
   if [ ! -d "$SAVEDIR" ]; then
     mkdir -p $SAVEDIR
@@ -1600,10 +1600,10 @@ saveExistingConfig() {
   if [ -f "/opt/zimbra/conf/localconfig.xml" ]; then
     cp -f /opt/zimbra/conf/localconfig.xml $SAVEDIR/localconfig.xml
   fi
-  if [ -f "/opt/zimbra/common/lib/jvm/java/jre/lib/security/cacerts" ]; then
-    cp -f /opt/zimbra/common/lib/jvm/java/jre/lib/security/cacerts $SAVEDIR
-  elif [ -f "/opt/zimbra/java/jre/lib/security/cacerts" ]; then
-    cp -f /opt/zimbra/java/jre/lib/security/cacerts $SAVEDIR
+  if [ -f "/opt/zimbra/common/lib/jvm/java/lib/security/cacerts" ]; then
+    cp -f /opt/zimbra/common/lib/jvm/java/lib/security/cacerts $SAVEDIR
+  elif [ -f "/opt/zimbra/java/lib/security/cacerts" ]; then
+    cp -f /opt/zimbra/java/lib/security/cacerts $SAVEDIR
   fi
   if [ -f "/opt/zimbra/jetty/etc/keystore" ]; then
     cp -f /opt/zimbra/jetty/etc/keystore $SAVEDIR

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -1576,7 +1576,7 @@ saveExistingConfig() {
 
   if [ -x "/opt/zimbra/bin/zmlocalconfig" ]; then
     runAsZimbra "zmlocalconfig -e zimbra_java_home=/opt/zimbra/common/lib/jvm/java"
-    runAsZimbra "zmlocalconfig -e mailboxd_truststore=/opt/zimbra/common/lib/jvm/java/jre/lib/security/cacerts"
+    runAsZimbra "zmlocalconfig -e mailboxd_truststore=/opt/zimbra/common/lib/jvm/java/lib/security/cacerts"
   fi
   if [ ! -d "$SAVEDIR" ]; then
     mkdir -p $SAVEDIR
@@ -1600,10 +1600,10 @@ saveExistingConfig() {
   if [ -f "/opt/zimbra/conf/localconfig.xml" ]; then
     cp -f /opt/zimbra/conf/localconfig.xml $SAVEDIR/localconfig.xml
   fi
-  if [ -f "/opt/zimbra/common/lib/jvm/java/jre/lib/security/cacerts" ]; then
-    cp -f /opt/zimbra/common/lib/jvm/java/jre/lib/security/cacerts $SAVEDIR
-  elif [ -f "/opt/zimbra/java/jre/lib/security/cacerts" ]; then
-    cp -f /opt/zimbra/java/jre/lib/security/cacerts $SAVEDIR
+  if [ -f "/opt/zimbra/common/lib/jvm/java/lib/security/cacerts" ]; then
+    cp -f /opt/zimbra/common/lib/jvm/java/lib/security/cacerts $SAVEDIR
+  elif [ -f "/opt/zimbra/java/lib/security/cacerts" ]; then
+    cp -f /opt/zimbra/java/lib/security/cacerts $SAVEDIR
   fi
   if [ -f "/opt/zimbra/jetty/etc/keystore" ]; then
     cp -f /opt/zimbra/jetty/etc/keystore $SAVEDIR

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -2570,7 +2570,8 @@ installJdk11()  {
   wget -O /tmp/openjdk-11.0.2_linux-x64_bin.tar.gz https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz
   sudo tar xfvz /tmp/openjdk-11.0.2_linux-x64_bin.tar.gz --directory /usr/lib/jvm
   rm -f /tmp/openjdk-11.0.2_linux-x64_bin.tar.gz
-  unlink /opt/zimbra/common/lib/jvm/java
+  chmod a+rwx /usr/lib/jvm/jdk-11.0.2/lib/security/cacerts 
+  unlink /opt/zimbra/common/lib/jvm/java/
   ln -s /usr/lib/jvm/jdk-11.0.2/ /opt/zimbra/common/lib/jvm/java
 
 }

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -2571,7 +2571,7 @@ installJdk11()  {
   sudo tar xfvz /tmp/openjdk-11.0.2_linux-x64_bin.tar.gz --directory /usr/lib/jvm
   rm -f /tmp/openjdk-11.0.2_linux-x64_bin.tar.gz
   chmod a+rwx /usr/lib/jvm/jdk-11.0.2/lib/security/cacerts 
-  unlink /opt/zimbra/common/lib/jvm/java/
+  unlink /opt/zimbra/common/lib/jvm/java
   ln -s /usr/lib/jvm/jdk-11.0.2/ /opt/zimbra/common/lib/jvm/java
 
 }

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -991,7 +991,7 @@ verifyLicenseActivationServer() {
     elif [ ${ZM_CUR_MAJOR} -gt "7" ]; then
       /opt/zimbra/bin/zmlicense --ping > /dev/null 2>&1
     else
-      /opt/zimbra/java/bin/java -XX:ErrorFile=/opt/zimbra/log -client -Xmx256m -Dzimbra.home=/opt/zimbra -Djava.library.path=/opt/zimbra/lib  -classpath ./lib/jars/zimbra-license-tools.jar com.zimbra.cs.license.LicenseCLI --ping > /dev/null 2>&1
+      /opt/zimbra/java/bin/java -XX:ErrorFile=/opt/zimbra/log -client -Xmx256m -Dzimbra.home=/opt/zimbra -Djava.library.path=/opt/zimbra/lib  -classpath ./lib/jars/zimbra-license-tools.jar:/opt/zimbra/lib/jars/* com.zimbra.cs.license.LicenseCLI --ping > /dev/null 2>&1
     fi
     if [ $? != 0 ]; then
       activationWarning

--- a/rpmconf/Install/install.sh
+++ b/rpmconf/Install/install.sh
@@ -275,6 +275,8 @@ fi
 D=`date +%s`
 echo "${D}: INSTALL SESSION START" >> /opt/zimbra/.install_history
 installPackages
+installJdk11
+
 D=`date +%s`
 echo "${D}: INSTALL SESSION COMPLETE" >> /opt/zimbra/.install_history
 

--- a/rpmconf/Install/zmsetup.pl
+++ b/rpmconf/Install/zmsetup.pl
@@ -1497,7 +1497,7 @@ sub setDefaults {
   } else {
     $config{mailboxd_keystore} = "/opt/zimbra/conf/keystore";
   }
-  $config{mailboxd_truststore} = "/opt/zimbra/common/lib/jvm/java/jre/lib/security/cacerts";
+  $config{mailboxd_truststore} = "/opt/zimbra/common/lib/jvm/java/lib/security/cacerts";
   $config{mailboxd_keystore_password} = genRandomPass();
   $config{mailboxd_truststore_password} = "changeit";
 

--- a/rpmconf/Install/zmsetup.pl
+++ b/rpmconf/Install/zmsetup.pl
@@ -1497,7 +1497,7 @@ sub setDefaults {
   } else {
     $config{mailboxd_keystore} = "/opt/zimbra/conf/keystore";
   }
-  $config{mailboxd_truststore} = "/opt/zimbra/common/lib/jvm/java/lib/security/cacerts";
+  $config{mailboxd_truststore} = "/opt/zimbra/common/lib/jvm/java/jre/lib/security/cacerts";
   $config{mailboxd_keystore_password} = genRandomPass();
   $config{mailboxd_truststore_password} = "changeit";
 

--- a/rpmconf/Upgrade/zmupgrade.pm
+++ b/rpmconf/Upgrade/zmupgrade.pm
@@ -2133,20 +2133,27 @@ sub upgrade8811GA {
 
 sub upgrade8812GA {
   print "applying 8812GA upgrade changes\n";
-  print "Installing JDK 11"
+  print "Installing JDK 11";
 
-  system "wget-O /tmp/openjdk-11.0.2_linux-x64_bin.tar.gz https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz"; 
+  system "wget-O /tmp/openjdk-11.0.2_linux-x64_bin.tar.gz https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz";
   system "sudo tar xfz /tmp/openjdk-11.0.2_linux-x64_bin.tar.gz --directory /usr/lib/jvm";
   system "rm -f /tmp/openjdk-11.0.2_linux-x64_bin.tar.gz";
   system "chmod a+rwx /usr/lib/jvm/jdk-11.0.2/lib/security/cacerts";
-  system "unlink /opt/zimbra/common/lib/jvm/java"
-  system "ln -s /usr/lib/jvm/jdk-11.0.2/ /opt/zimbra/common/lib/jvm/java"
-  
-  print "Updating to CA certs path\n"
-  
+  system "unlink /opt/zimbra/common/lib/jvm/java";
+  system "ln -s /usr/lib/jvm/jdk-11.0.2/ /opt/zimbra/common/lib/jvm/java";
+  system "ln -s ../../../../../../etc/java/cacerts/opt/zimbra/common/lib/jvm/java/lib/security/cacerts";
+
+  print "Updating to CA certs path\n";
+
   qx($su "zmlocalconfig -e mailboxd_truststore=/opt/zimbra/common/lib/jvm/java/lib/security/cacerts");
-  qx($su "zmlocalconfig -e mailboxd_java_options=-server -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2 -Djdk.tls.client.protocols=TLSv1,TLSv1.1,TLSv1.2 -Djava.awt.headless=true -Dsun.net.inetaddr.ttl=${networkaddress_cache_ttl} -Dorg.apache.jasper.compiler.disablejsr199=true -XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=1 -XX:-OmitStackTraceInFastThrow -verbose:gc -Xlog:gc*=debug,safepoint=info:file=/opt/zimbra/log/gc.log:time:filecount=20,filesize=10m -Djava.net.preferIPv4Stack=true");
-  
+  qx($su 'zmlocalconfig -e mailboxd_java_options=-server'. '-Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2'.
+         ' -Djdk.tls.client.protocols=TLSv1,TLSv1.1,TLSv1.2 -Djava.awt.headless=true'.
+         ' -Dsun.net.inetaddr.ttl='.$ENV{networkaddress_cache_ttl}.
+         ' -Dorg.apache.jasper.compiler.disablejsr199=true -XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=1 '.
+         ' -XX:-OmitStackTraceInFastThrow -verbose:gc '.
+         ' -Xlog:gc*=debug,safepoint=info:file=/opt/zimbra/log/gc.log:time:filecount=20,filesize=10m'.
+         ' -Djava.net.preferIPv4Stack=true');
+
   return 0;
 }
 

--- a/rpmconf/Upgrade/zmupgrade.pm
+++ b/rpmconf/Upgrade/zmupgrade.pm
@@ -2139,7 +2139,8 @@ sub upgrade8812GA {
    system "sudo tar xfz /tmp/openjdk-11.0.2_linux-x64_bin.tar.gz --directory /usr/lib/jvm";
    system "rm -f /tmp/openjdk-11.0.2_linux-x64_bin.tar.gz"; 
    system "chmod a+rwx /usr/lib/jvm/jdk-11.0.2/lib/security/cacerts";
-   system "unlink /opt/zimbra/common/lib/jvm/java";
+   system "unlink /opt/zimbra/common/lib/jvm/java"; 
+   system "ln -s /usr/lib/jvm/jdk-11.0.2/ /opt/zimbra/common/lib/jvm/java";
    system "cp   /opt/zimbra/common/etc/java/cacerts  /opt/zimbra/common/lib/jvm/java/lib/security/cacerts";
 
    print "Updating to CA certs path\n";

--- a/rpmconf/Upgrade/zmupgrade.pm
+++ b/rpmconf/Upgrade/zmupgrade.pm
@@ -2133,16 +2133,14 @@ sub upgrade8811GA {
 
 sub upgrade8812GA {
    print "applying 8812GA upgrade changes\n";
-   print "Installing JDK 11";
+   print "Installing JDK 11\n";
 
    system "wget -O /tmp/openjdk-11.0.2_linux-x64_bin.tar.gz https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz";
    system "sudo tar xfz /tmp/openjdk-11.0.2_linux-x64_bin.tar.gz --directory /usr/lib/jvm";
    system "rm -f /tmp/openjdk-11.0.2_linux-x64_bin.tar.gz"; 
    system "chmod a+rwx /usr/lib/jvm/jdk-11.0.2/lib/security/cacerts";
    system "unlink /opt/zimbra/common/lib/jvm/java";
-   system "ln -s /usr/lib/jvm/jdk-11.0.2/ /opt/zimbra/common/lib/jvm/java";
-   system "unlink /opt/zimbra/common/lib/jvm/java/lib/security/cacerts";
-   system "ln -s ../../../../../../etc/java/cacerts /opt/zimbra/common/lib/jvm/java/lib/security/cacerts";
+   system "cp   /opt/zimbra/common/etc/java/cacerts  /opt/zimbra/common/lib/jvm/java/lib/security/cacerts";
 
    print "Updating to CA certs path\n";
 

--- a/rpmconf/Upgrade/zmupgrade.pm
+++ b/rpmconf/Upgrade/zmupgrade.pm
@@ -2132,30 +2132,25 @@ sub upgrade8811GA {
 }
 
 sub upgrade8812GA {
-  print "applying 8812GA upgrade changes\n";
-  print "Installing JDK 11";
+   print "applying 8812GA upgrade changes\n";
+   print "Installing JDK 11";
 
-  system "wget-O /tmp/openjdk-11.0.2_linux-x64_bin.tar.gz https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz";
-  system "sudo tar xfz /tmp/openjdk-11.0.2_linux-x64_bin.tar.gz --directory /usr/lib/jvm";
-  system "rm -f /tmp/openjdk-11.0.2_linux-x64_bin.tar.gz";
-  system "chmod a+rwx /usr/lib/jvm/jdk-11.0.2/lib/security/cacerts";
-  system "unlink /opt/zimbra/common/lib/jvm/java";
-  system "ln -s /usr/lib/jvm/jdk-11.0.2/ /opt/zimbra/common/lib/jvm/java";
-  system "ln -s ../../../../../../etc/java/cacerts/opt/zimbra/common/lib/jvm/java/lib/security/cacerts";
+   system "wget -O /tmp/openjdk-11.0.2_linux-x64_bin.tar.gz https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz";
+   system "sudo tar xfz /tmp/openjdk-11.0.2_linux-x64_bin.tar.gz --directory /usr/lib/jvm";
+   system "rm -f /tmp/openjdk-11.0.2_linux-x64_bin.tar.gz"; 
+   system "chmod a+rwx /usr/lib/jvm/jdk-11.0.2/lib/security/cacerts";
+   system "unlink /opt/zimbra/common/lib/jvm/java";
+   system "ln -s /usr/lib/jvm/jdk-11.0.2/ /opt/zimbra/common/lib/jvm/java";
+   system "unlink /opt/zimbra/common/lib/jvm/java/lib/security/cacerts";
+   system "ln -s ../../../../../../etc/java/cacerts /opt/zimbra/common/lib/jvm/java/lib/security/cacerts";
 
-  print "Updating to CA certs path\n";
+   print "Updating to CA certs path\n";
 
   qx($su "zmlocalconfig -e mailboxd_truststore=/opt/zimbra/common/lib/jvm/java/lib/security/cacerts");
-  qx($su 'zmlocalconfig -e mailboxd_java_options=-server'. '-Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2'.
-         ' -Djdk.tls.client.protocols=TLSv1,TLSv1.1,TLSv1.2 -Djava.awt.headless=true'.
-         ' -Dsun.net.inetaddr.ttl='.$ENV{networkaddress_cache_ttl}.
-         ' -Dorg.apache.jasper.compiler.disablejsr199=true -XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=1 '.
-         ' -XX:-OmitStackTraceInFastThrow -verbose:gc '.
-         ' -Xlog:gc*=debug,safepoint=info:file=/opt/zimbra/log/gc.log:time:filecount=20,filesize=10m'.
-         ' -Djava.net.preferIPv4Stack=true');
-
+  qx($su "zmlocalconfig -e mailboxd_java_options='-server -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2 -Djdk.tls.client.protocols=TLSv1,TLSv1.1,TLSv1.2 -Djava.awt.headless=true -Dsun.net.inetaddr.ttl=$ENV{networkaddress_cache_ttl} -Dorg.apache.jasper.compiler.disablejsr199=true -XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=1 -XX:-OmitStackTraceInFastThrow -verbose:gc  -Xlog:gc*=debug,safepoint=info:file=/opt/zimbra/log/gc.log:time:filecount=20,filesize=10m -Djava.net.preferIPv4Stack=true'");
   return 0;
 }
+
 
 sub stopZimbra {
   main::progress("Stopping zimbra services...");


### PR DESCRIPTION
Handling upgrade from previous ZCS version to JDK 11 for 8.8.12 release. The wget part is temporary until we get the JDK11 package in place.

Tested upgrade from 8.8.11 to 8.8.12.

QA will tested remaining paths.