### PR TITLE
ZBUG-1148:Loosing table format with owasp sanitizer

### DIFF
--- a/instructions/FOSS_repo_list.pl
+++ b/instructions/FOSS_repo_list.pl
@@ -4,6 +4,7 @@
    { name => "ical4j-0.9.16-patched",                },
    { name => "junixsocket",                         tag    => "junixsocket-parent-2.0.4", remote => "gh-ks",},
    { name => "nekohtml-1.9.13",                      },
+   { name => "java-html-sanitizer-release-20190610.1",},
    { name => "zm-admin-console",                     },
    { name => "zm-admin-help-common",                 },
    { name => "zm-ajax",                              },

--- a/instructions/FOSS_staging_list.pl
+++ b/instructions/FOSS_staging_list.pl
@@ -331,6 +331,11 @@
       "stage_cmd"   => undef,
    },
    {
+      "dir"         => "java-html-sanitizer-release-20190610.1",
+      "ant_targets" => ["jar"],
+      "stage_cmd"   => undef,
+   },
+   {
       "dir"         => "ical4j-0.9.16-patched",
       "ant_targets" => [ "clean-compile", "package" ],
       "stage_cmd"   => undef,


### PR DESCRIPTION
Upgrading OWASP library to latest version, which resolves ZBUG-1148
Added fix for ZCS-7497 in new owasp library

Ref PRs:
https://github.com/Zimbra/java-html-sanitizer-release-20190610.1/pull/1
https://github.com/Zimbra/zm-zcs-lib/pull/54
https://github.com/Zimbra/zm-mailbox/pull/963