### PR TITLE
ZCS-8730:database changes to support ABQ

### DIFF
--- a/instructions/bundling-scripts/zimbra-core.sh
+++ b/instructions/bundling-scripts/zimbra-core.sh
@@ -486,7 +486,7 @@ main()
    Copy ${repoDir}/zm-db-conf/src/db/migration/migrate20180301-ZimbraChat.pl                        ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/scripts/migrate20180301-ZimbraChat.pl
    Copy ${repoDir}/zm-db-conf/src/db/migration/migrate20190401-ZimbraChat.pl                        ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/scripts/migrate20190401-ZimbraChat.pl
    Copy ${repoDir}/zm-db-conf/src/db/migration/migrate20190611-ZimbraChat.pl                        ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/scripts/migrate20190611-ZimbraChat.pl
-   Copy ${repoDir}/zm-db-conf/src/db/migration/migrate20200219-MobileDevices.pl                     ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/scripts/migrate20200219-MobileDevices.pl
+   Copy ${repoDir}/zm-db-conf/src/db/migration/migrate20200226-MobileDevices.pl                     ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/scripts/migrate20200226-MobileDevices.pl
    Copy ${repoDir}/zm-db-conf/src/db/migration/migrateAmavisLdap20050810.pl                         ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/scripts/migrateAmavisLdap20050810.pl
    Copy ${repoDir}/zm-db-conf/src/db/migration/migrateClearSpamFlag.pl                              ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/scripts/migrateClearSpamFlag.pl
    Copy ${repoDir}/zm-db-conf/src/db/migration/migrateLargeMetadata.pl                              ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/scripts/migrateLargeMetadata.pl


### PR DESCRIPTION
Replacing migration script name change for ZCS-8670 with ZCS-8730.

Testing to be done by QA:
test migration script

Ref PR:
https://github.com/Zimbra/zm-mailbox/pull/1026
https://github.com/Zimbra/zm-db-conf/pull/10