### PR TITLE
ZCS-9017: Changes for RHEL8

### DIFF
--- a/instructions/bundling-scripts/zimbra-ldap.sh
+++ b/instructions/bundling-scripts/zimbra-ldap.sh
@@ -89,8 +89,6 @@ CreateRhelPackage()
         ${repoDir}/zm-build/${currentScript}.spec
     echo "%attr(-, root, root) /opt/zimbra/common/etc/openldap/zimbra/config/cn=config/olcDatabase={2}mdb" >> \
         ${repoDir}/zm-build/${currentScript}.spec
-    echo "%attr(-, root, root) /opt/zimbra/common/etc/openldap/zimbra/config/cn=config/olcDatabase={2}mdb/*" >> \
-        ${repoDir}/zm-build/${currentScript}.spec
     echo "%attr(-, root, root) /opt/zimbra/common/etc/openldap/zimbra/schema" >> \
         ${repoDir}/zm-build/${currentScript}.spec
     echo "%attr(-, root, root) /opt/zimbra/common/etc/openldap/zimbra/schema/*" >> \

--- a/rpmconf/Build/get_plat_tag.sh
+++ b/rpmconf/Build/get_plat_tag.sh
@@ -25,6 +25,11 @@ if [ -f /etc/redhat-release ]; then
     i=""
   fi
 
+  grep "Red Hat Enterprise Linux.*release 8" /etc/redhat-release > /dev/null 2>&1
+  if [ $? = 0 ]; then
+    echo "RHEL8${i}"
+    exit 0
+  fi
   grep "Red Hat Enterprise Linux.*release 7" /etc/redhat-release > /dev/null 2>&1
   if [ $? = 0 ]; then
     echo "RHEL7${i}"
@@ -36,6 +41,11 @@ if [ -f /etc/redhat-release ]; then
     exit 0
   fi
 
+  grep "CentOS Linux release 8" /etc/redhat-release > /dev/null 2>&1
+  if [ $? = 0 ]; then
+    echo "RHEL8${i}"
+    exit 0
+  fi
   grep "CentOS Linux release 7" /etc/redhat-release > /dev/null 2>&1
   if [ $? = 0 ]; then
     echo "RHEL7${i}"
@@ -47,6 +57,11 @@ if [ -f /etc/redhat-release ]; then
     exit 0
   fi
 
+  grep "Scientific Linux release 8" /etc/redhat-release > /dev/null 2>&1
+  if [ $? = 0 ]; then
+    echo "RHEL8${i}"
+    exit 0
+  fi
   grep "Scientific Linux release 7" /etc/redhat-release > /dev/null 2>&1
   if [ $? = 0 ]; then
     echo "RHEL7${i}"

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -1905,7 +1905,7 @@ removeExistingInstall() {
             if [ $? = 0 ]; then
               echo -n "Cleaning up /etc/rsyslog.conf..."
               sed -i -e '/zimbra/d' /etc/rsyslog.conf
-              if [ $PLATFORM = "RHEL6_64" -o $PLATFORM = "RHEL7_64" ]; then
+              if [ $PLATFORM = "RHEL6_64" -o $PLATFORM = "RHEL7_64" -o $PLATFORM = "RHEL8_64" ]; then
                 sed -i -e 's/^*.info;local0.none;local1.none;mail.none;auth.none/*.info/' /etc/rsyslog.conf
                 sed -i -e 's/^*.info;local0.none;local1.none;auth.none/*.info/' /etc/rsyslog.conf
               fi
@@ -2194,6 +2194,8 @@ fi
         repo="rhel6"
       elif [ $PLATFORM = "RHEL7_64" ]; then
         repo="rhel7"
+     elif [ $PLATFORM = "RHEL8_64" ]; then
+        repo="rhel8"
       else
         print "Aborting, unknown platform: $PLATFORM"
         exit 1
@@ -2764,7 +2766,7 @@ getPlatformVars() {
       PACKAGEEXT='rpm'
       PACKAGEQUERY='rpm -q'
       PACKAGEVERIFY='rpm -K'
-      if [ $PLATFORM = "RHEL6_64" -o $PLATFORM = "RHEL7_64" ]; then
+      if [ $PLATFORM = "RHEL6_64" -o $PLATFORM = "RHEL7_64" -o $PLATFORM = "RHEL8_64" ]; then
          STORE_PACKAGES="libreoffice libreoffice-headless"
       fi
       DumpFileDetailsFromPackage() {


### PR DESCRIPTION
Removed below line from zimbra-ldap.spec, because rpmbuild version of RHEL8 not accepting this format as it contains {} .
/opt/zimbra/common/etc/openldap/zimbra/config/cn=config/olcDatabase={2}mdb/*"

However it will be covered by /opt/zimbra/common/etc/openldap/zimbra/config/*