### PR TITLE
ZCS-10322: Added custom-mimetypes.xml

### DIFF
--- a/instructions/bundling-scripts/zimbra-store.sh
+++ b/instructions/bundling-scripts/zimbra-store.sh
@@ -54,6 +54,7 @@ main()
 
     cp -f ${repoDir}/zm-mailbox/store-conf/conf/owasp_policy.xml ${repoDir}/zm-build/${currentPackage}/opt/zimbra/conf/owasp_policy.xml
     cp -f ${repoDir}/zm-mailbox/store-conf/conf/antisamy.xml ${repoDir}/zm-build/${currentPackage}/opt/zimbra/conf/antisamy.xml
+    cp -f ${repoDir}/zm-mailbox/store-conf/conf/custom-mimetypes.xml ${repoDir}/zm-build/${currentPackage}/opt/zimbra/conf/custom-mimetypes.xml
 
     echo -e "\tCopy extensions-extra files of /op/zimbra/" >> ${buildLogFile}
     mkdir -p ${repoDir}/zm-build/${currentPackage}/opt/zimbra/extensions-extra/openidconsumer


### PR DESCRIPTION
Added `custom-mimetypes.xml` in `store-conf` which will be copied over to the `/opt/zimbra/conf` directory where we can be able override the existing mimetypes and can be able to map the content-type to any of the extensions with a higher magic priority.

**Related PR:**
[zm-zcs-lib](https://github.com/Zimbra/zm-zcs-lib/pull/72)
[zm-mailbox](https://github.com/Zimbra/zm-mailbox/pull/1132)