### PR TITLE
EAS - Bring 16.0/16.1 support to z9

### DIFF
--- a/instructions/bundling-scripts/zimbra-core.sh
+++ b/instructions/bundling-scripts/zimbra-core.sh
@@ -487,6 +487,7 @@ main()
    Copy ${repoDir}/zm-db-conf/src/db/migration/migrate20190401-ZimbraChat.pl                        ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/scripts/migrate20190401-ZimbraChat.pl
    Copy ${repoDir}/zm-db-conf/src/db/migration/migrate20190611-ZimbraChat.pl                        ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/scripts/migrate20190611-ZimbraChat.pl
    Copy ${repoDir}/zm-db-conf/src/db/migration/migrate20210506-BriefcaseApi.pl                      ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/scripts/migrate20210506-BriefcaseApi.pl
+   Copy ${repoDir}/zm-db-conf/src/db/migration/migrate20200625-MobileDevices.pl                     ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/scripts/migrate20200625-MobileDevices.pl
    Copy ${repoDir}/zm-db-conf/src/db/migration/migrate20210319-MobileDevices.pl                     ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/scripts/migrate20210319-MobileDevices.pl
    Copy ${repoDir}/zm-db-conf/src/db/migration/migrateAmavisLdap20050810.pl                         ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/scripts/migrateAmavisLdap20050810.pl
    Copy ${repoDir}/zm-db-conf/src/db/migration/migrateClearSpamFlag.pl                              ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/scripts/migrateClearSpamFlag.pl

--- a/instructions/bundling-scripts/zimbra-core.sh
+++ b/instructions/bundling-scripts/zimbra-core.sh
@@ -487,6 +487,7 @@ main()
    Copy ${repoDir}/zm-db-conf/src/db/migration/migrate20190401-ZimbraChat.pl                        ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/scripts/migrate20190401-ZimbraChat.pl
    Copy ${repoDir}/zm-db-conf/src/db/migration/migrate20190611-ZimbraChat.pl                        ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/scripts/migrate20190611-ZimbraChat.pl
    Copy ${repoDir}/zm-db-conf/src/db/migration/migrate20210506-BriefcaseApi.pl                      ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/scripts/migrate20210506-BriefcaseApi.pl
+   Copy ${repoDir}/zm-db-conf/src/db/migration/migrate20210319-MobileDevices.pl                     ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/scripts/migrate20210319-MobileDevices.pl
    Copy ${repoDir}/zm-db-conf/src/db/migration/migrateAmavisLdap20050810.pl                         ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/scripts/migrateAmavisLdap20050810.pl
    Copy ${repoDir}/zm-db-conf/src/db/migration/migrateClearSpamFlag.pl                              ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/scripts/migrateClearSpamFlag.pl
    Copy ${repoDir}/zm-db-conf/src/db/migration/migrateLargeMetadata.pl                              ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/scripts/migrateLargeMetadata.pl

--- a/rpmconf/Upgrade/zmupgrade.pm
+++ b/rpmconf/Upgrade/zmupgrade.pm
@@ -41,7 +41,7 @@ chomp $rundir;
 my $scriptDir = "/opt/zimbra/libexec/scripts";
 
 my $lowVersion = 52;
-my $hiVersion = 112; # this should be set to the DB version expected by current server code
+my $hiVersion = 118; # this should be set to the DB version expected by current server code
 
 my $needSlapIndexing = 0;
 my $mysqlcnfUpdated = 0;
@@ -88,6 +88,7 @@ my %updateScripts = (
   '109' => "migrate20190401-ZimbraChat.pl",            #8.8.15
   '110' => "migrate20190611-ZimbraChat.pl",            #8.8.15
   '111' => "migrate20210506-BriefcaseApi.pl",          #9.1.0
+  '117' => "migrate20210319-MobileDevices.pl",              # Zimbra X
 );
 
 my %updateFuncs = (

--- a/rpmconf/Upgrade/zmupgrade.pm
+++ b/rpmconf/Upgrade/zmupgrade.pm
@@ -41,7 +41,7 @@ chomp $rundir;
 my $scriptDir = "/opt/zimbra/libexec/scripts";
 
 my $lowVersion = 52;
-my $hiVersion = 118; # this should be set to the DB version expected by current server code
+my $hiVersion = 114; # this should be set to the DB version expected by current server code
 
 my $needSlapIndexing = 0;
 my $mysqlcnfUpdated = 0;
@@ -88,7 +88,8 @@ my %updateScripts = (
   '109' => "migrate20190401-ZimbraChat.pl",            #8.8.15
   '110' => "migrate20190611-ZimbraChat.pl",            #8.8.15
   '111' => "migrate20210506-BriefcaseApi.pl",          #9.1.0
-  '117' => "migrate20210319-MobileDevices.pl",              # Zimbra X
+  '112' => "migrate20200625-MobileDevices.pl",         #Zimbra X
+  '113' => "migrate20210319-MobileDevices.pl",         #Zimbra X
 );
 
 my %updateFuncs = (


### PR DESCRIPTION
bringing eas and abq from zx to z9

branch `eas_zx` is used for below repositories
1. zm-mailbox
2. zm-sync-common
3. zm-sync-store
4. zm-sync-client
5. zm-sync-tools
6. zm-db-conf
7. zm-build
