### PR TITLE
bugfix/ZCS-10808 : Install rabbit-mq while upgrading

### DIFF
--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -2276,6 +2276,9 @@ getInstallPackages() {
         elif [ $i = "zimbra-proxy" ]; then
           PROXY_SELECTED="yes"
         fi
+        elif [ $i = "zimbra-onlyoffice" ]; then
+          ONLYOFFICE_SELECTED="yes"
+        fi
         continue
       fi
     fi


### PR DESCRIPTION
Problem:
While upgrading rabbitmq is removed first, but not picked again for installation.

FIX :
Check if onlyoffice is being upgraded. If it is being upgraded, install rabbit-mq
