### PR TITLE
ZCS-10808-1 :Install rabbit-mq while upgrading

### DIFF
--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -2275,7 +2275,6 @@ getInstallPackages() {
           MTA_SELECTED="yes"
         elif [ $i = "zimbra-proxy" ]; then
           PROXY_SELECTED="yes"
-        fi
         elif [ $i = "zimbra-onlyoffice" ]; then
           ONLYOFFICE_SELECTED="yes"
         fi


### PR DESCRIPTION
There is an extra `fi` which is causing the installation to fail.