### PR TITLE
ZCS-10890 : Allow onlyoffice server name change

### DIFF
--- a/rpmconf/Install/zmsetup.pl
+++ b/rpmconf/Install/zmsetup.pl
@@ -3664,14 +3664,14 @@ sub createOnlyofficeMenu {
     #    set the server host name at server level config
     if (isEnabled("zimbra-store")) {
       $config{ONLYOFFICESTANDALONE} = "no";
-      $config{ONLYOFFICEHOSTNAME} = $config{HOSTNAME};
     } else {
       $config{ONLYOFFICESTANDALONE} = "yes";
-      if ($config{ONLYOFFICEHOSTNAME} eq "") {
-        $config{ONLYOFFICEHOSTNAME} = $config{HOSTNAME};
-      }
-
     }
+
+    if ($config{ONLYOFFICEHOSTNAME} eq "") {
+        $config{ONLYOFFICEHOSTNAME} = $config{HOSTNAME};
+    }
+
     $$lm{menuitems}{$i} = {
       "prompt" => "Onlyoffice server:",
       "var" => \$config{ONLYOFFICEHOSTNAME},


### PR DESCRIPTION
Problem: It would not allow different server name to be added in case of onlyoffice being installed with mailbox

Test: 
Changed zmsetup.pl : `createOnlyofficeMenu` to allow overwrite