### PR TITLE
Add support for AlmaLinux 8

### DIFF
--- a/rpmconf/Build/get_plat_tag.sh
+++ b/rpmconf/Build/get_plat_tag.sh
@@ -73,6 +73,12 @@ if [ -f /etc/redhat-release ]; then
     exit 0
   fi
 
+  grep "AlmaLinux release 8" /etc/redhat-release > /dev/null 2>&1
+  if [ $? = 0 ]; then
+    echo "RHEL8${i}"
+    exit 0
+  fi
+
   grep "Fedora release 23" /etc/redhat-release >/dev/null 2>&1
   if [ $? = 0 ]; then
     echo "F23${i}"


### PR DESCRIPTION
This patch adds support for detecting AlmaLinux 8 as a valid RHEL8 variant. With CentOS Linux ending in december, AlmaLinux will be used more and more