### PR TITLE
Add Rocky Linux 8

### DIFF
--- a/rpmconf/Build/get_plat_tag.sh
+++ b/rpmconf/Build/get_plat_tag.sh
@@ -57,6 +57,12 @@ if [ -f /etc/redhat-release ]; then
     exit 0
   fi
 
+  grep "Rocky Linux release 8" /etc/redhat-release > /dev/null 2>&1
+  if [ $? = 0 ]; then
+    echo "RHEL8${i}"
+    exit 0
+  fi
+
   grep "Scientific Linux release 8" /etc/redhat-release > /dev/null 2>&1
   if [ $? = 0 ]; then
     echo "RHEL8${i}"
@@ -92,6 +98,11 @@ if [ -f /etc/redhat-release ]; then
   grep "CentOS release" /etc/redhat-release > /dev/null 2>&1
   if [ $? = 0 ]; then
     echo "CentOSUNKNOWN${i}"
+    exit 0
+  fi
+  grep "Rocky Linux release" /etc/redhat-release > /dev/null 2>&1
+  if [ $? = 0 ]; then
+    echo "RockyUNKNOWN${i}"
     exit 0
   fi
   grep "Fedora Core release" /etc/redhat-release > /dev/null 2>&1


### PR DESCRIPTION
CentOS Linux 8 reaches EOL on 2021-12-31 and is superseeded by Rocky Linux 8 as alternative bug-for-bug compatible RHEL 8 rebuild.