### PR TITLE
Fix for ZCS-11090

### DIFF
--- a/instructions/bundling-scripts/zimbra-core.sh
+++ b/instructions/bundling-scripts/zimbra-core.sh
@@ -339,6 +339,7 @@ main()
    Copy ${repoDir}/zm-core-utils/src/libexec/zmiostat                                               ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/zmiostat
    Copy ${repoDir}/zm-core-utils/src/libexec/zmiptool                                               ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/zmiptool
    Copy ${repoDir}/zm-core-utils/src/libexec/zmjavawatch                                            ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/zmjavawatch
+   Copy ${repoDir}/zm-core-utils/src/libexec/zmjettyenablelogging                                   ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/zmjettyenablelogging
    Copy ${repoDir}/zm-core-utils/src/libexec/zmjsprecompile                                         ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/zmjsprecompile
    Copy ${repoDir}/zm-core-utils/src/libexec/zmlogger                                               ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/zmlogger
    Copy ${repoDir}/zm-core-utils/src/libexec/zmloggerinit                                           ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/zmloggerinit

--- a/instructions/bundling-scripts/zimbra-store.sh
+++ b/instructions/bundling-scripts/zimbra-store.sh
@@ -270,6 +270,7 @@ main()
     cp -f ${repoDir}/zm-jetty-conf/conf/jetty/modules/*.mod.in ${repoDir}/zm-build/${currentPackage}/opt/zimbra/jetty_base/modules
     cp -f ${repoDir}/zm-jetty-conf/conf/jetty/start.d/*.ini.in   ${repoDir}/zm-build/${currentPackage}/opt/zimbra/jetty_base/start.d
     cp -f ${repoDir}/zm-jetty-conf/conf/jetty/modules/npn/*.mod  ${repoDir}/zm-build/${currentPackage}/opt/zimbra/jetty_base/modules/npn
+    cp -f ${repoDir}/zm-jetty-conf/conf/jetty/jetty-logging.properties ${repoDir}/zm-build/${currentPackage}/opt/zimbra/jetty_base/etc/
 
     cp -f ${repoDir}/zm-zimlets/conf/web.xml.production ${repoDir}/zm-build/${currentPackage}/opt/zimbra/jetty_base/etc/zimlet.web.xml.in
 

--- a/rpmconf/Install/zmsetup.pl
+++ b/rpmconf/Install/zmsetup.pl
@@ -7318,6 +7318,10 @@ sub applyConfig {
     # Initialize application server specific items
     # only after the application server is running.
     if (isEnabled("zimbra-store")) {
+      progress("Enabling jetty logging...");
+      system("/opt/zimbra/libexec/zmjettyenablelogging > /dev/null 2>&1");
+      progress("done.\n");
+
       configInstallZimlets();
 
       progress ( "Restarting mailboxd...");


### PR DESCRIPTION
**Problem:**
A log about an error on jetty is not written in zmmailboxd.out on ZCS 9.0.0 Patch 13 and later.

**Root cause:**
`/opt/zimbra/jetty_base/common/lib/slf4j-api-1.7.30.jar` has been added since Patch 13.
On Patch12 or prior, org.eclipse.jetty.util.log.class is not defined, org.slf4j.Logger does not exist in classpath, and then org.eclipse.jetty.util.log.StdErrLog is used.

(zmmailboxd.out)
```
2021-12-06 20:24:53.097:INFO::main: Logging initialized @1342ms to org.eclipse.jetty.util.log.StdErrLog
```

After Patch 13, org.eclipse.jetty.util.log.class is not defined, org.slf4j.Logger exists in classpath, and then org.eclipse.jetty.util.log.Slf4jLog is used. However, no SFL4J binding is defined. Then it falls back to NOP or /dev/null.

(zmmailboxd.out)
```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```
Reference:
https://docs.huihoo.com/jetty/the-definitive-reference/configuring-logging.html
* _If property org.eclipse.jetty.util.log.class is defined, load the class it defines as the Logger implementation from the server classpath._
* _If the class org.slf4j.Logger exists in server classpath, the Jetty implementation becomes org.eclipse.jetty.util.log.Slf4jLog._
* _If no logger implementation is specified, default to org.eclipse.jetty.util.log.StdErrLog._

http://www.slf4j.org/manual.html
_you simply drop one and only one binding of your choice onto the appropriate class path location._
See also a figure on the page.

**Approach:**
Adding jetty-logging.properties in jetty_home/resources/ to set `org.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.StdErrLog`.
Since a plain jetty package is deployed on a server at zimbra installation, we add jetty_base/etc/jetty-logging.properties and create a symblic link on jetty_home/resources/ to the file. 

**PRs**
* add `jetty-logging.properties` https://github.com/Zimbra/zm-jetty-conf/pull/16
* add `zmjettyenablelogging` script which creates a symbolic link as mentioned the above - https://github.com/Zimbra/zm-core-utils/pull/98
* fix package build scripts to add them. Fix zmsetup.pl to run `zmjettyenablelogging` at zimbra installation. - this PR

**Tested by developer**
* jetty logging was enabled after zimbra clean/upgrade install
* jetty logging was enabled after deploying jetty_base/etc/jetty-logging.properties and zmjettyenablelogging and ran zmjettyenablelogging manually
* checked error handling (`if` statements) of zmjettyenablelogging