### PR TITLE
ZCS-11305: option to choose installation of patch packages when installing custom build in lab machines

### DIFF
--- a/rpmconf/Install/Util/globals.sh
+++ b/rpmconf/Install/Util/globals.sh
@@ -81,7 +81,7 @@ REMOVE="no"
 UPGRADE="no"
 HOSTNAME=`hostname --fqdn`
 ZIMBRAINTERNAL=no
-echo $HOSTNAME | egrep -qe 'eng.synacor.com$|eng.zimbra.com$|lab.zimbra.com$' > /dev/null 2>&1
+echo $HOSTNAME | egrep -qe 'eng.synacor.com$|eng.zimbra.com$|lab.zimbra.com$|zimbradev.com$' > /dev/null 2>&1
 if [ $? = 0 ]; then
   ZIMBRAINTERNAL=yes
 fi

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -862,7 +862,7 @@ verifyUpgrade() {
       if [ x"$SKIP_ACTIVATION_CHECK" = "xno" ]; then
         if [ -x "bin/checkLicense.pl" ]; then
           echo "Validating existing license is not expired and qualifies for upgrade"
-          echo $HOSTNAME | egrep -qe 'eng.vmware.com$|eng.zimbra.com$|lab.zimbra.com$' > /dev/null 2>&1
+          echo $HOSTNAME | egrep -qe 'eng.vmware.com$|eng.zimbra.com$|lab.zimbra.com$|zimbradev.com$' > /dev/null 2>&1
           if [ $? = 0 ]; then
             # echo "Running bin/checkLicense.pl -i -v $ZM_INST_VERSION"
             `bin/checkLicense.pl -i -v $ZM_INST_VERSION >/dev/null`
@@ -2107,7 +2107,7 @@ configurePackageServer() {
       USE_ZIMBRA_PACKAGE_SERVER="yes"
       PACKAGE_SERVER="repo.zimbra.com"
       response="no"
-      echo $HOSTNAME | egrep -qe 'eng.vmware.com$|eng.zimbra.com$|lab.zimbra.com$' > /dev/null 2>&1
+      echo $HOSTNAME | egrep -qe 'eng.vmware.com$|eng.zimbra.com$|lab.zimbra.com$|zimbradev.com$' > /dev/null 2>&1
       if [ $? = 0 ]; then
         askYN "Use internal development repo" "N"
         if [ $response = "yes" ]; then
@@ -2317,6 +2317,11 @@ getInstallPackages() {
 
     # askInstallPkgYN args : PROMPT REQUIRE_STORE=yes|no YES_STORE_DEFAULT=Y|N NO_STORE_DEFAULT=Y|N
 
+    ZIMBRAINTERNAL=no
+    echo $HOSTNAME | egrep -qe 'eng.zimbra.com$|lab.zimbra.com$|zimbradev.com$' > /dev/null 2>&1
+    if [ $? = 0 ]; then
+       ZIMBRAINTERNAL=yes
+    fi
     if [ $i = "zimbra-license-tools" ]; then
       response="yes"
     elif [ $i = "zimbra-modern-ui" ]; then
@@ -2324,11 +2329,23 @@ getInstallPackages() {
     elif [ $i = "zimbra-modern-zimlets" ]; then
       ifStoreSelectedY
     elif [ $i = "zimbra-patch" ]; then
-      ifStoreSelectedY
+        if [ x"$ZIMBRAINTERNAL" = "xyes" ] && [ $STORE_SELECTED = "yes" ]; then
+            askYN "Install $i" "Y"
+        else
+            ifStoreSelectedY
+        fi
     elif [ $i = "zimbra-mta-patch" ]; then
-      response="$MTA_SELECTED"
+        if [ x"$ZIMBRAINTERNAL" = "xyes" ] && [ $MTA_SELECTED = "yes" ]; then
+            askYN "Install $i" "Y"
+        else
+            response="$MTA_SELECTED"
+        fi
     elif [ $i = "zimbra-proxy-patch" ]; then
-      response="$PROXY_SELECTED"
+        if [ x"$ZIMBRAINTERNAL" = "xyes" ] && [ $PROXY_SELECTED = "yes" ]; then
+            askYN "Install $i" "Y"
+        else
+            response="$PROXY_SELECTED"
+        fi
     elif [ $i = "zimbra-license-extension" ]; then
       ifStoreSelectedY
     elif [ $i = "zimbra-network-store" ]; then


### PR DESCRIPTION
As a developer I want a system where we can create custom build from jenkins including custom changes, which can be installed in lab machine for testing and development process.

Currently when we create custom build it has all changes in the package but at installation time zimbra-patch, zimbra-mta-patch, zimbra-proxy-patch packages overwrites those changes with older files, so we may introduce an extra option in installation time to install zimbra-patch, zimbra-mta-patch, zimbra-proxy-patch packages or not, this option should be visible only when installing this build in lab machines, this option should not be present for customers.