### PR TITLE
ZBUG-2633:Upgraded jetty to 9.4.46.v20220331

### DIFF
--- a/rpmconf/Spec/zimbra-store.deb
+++ b/rpmconf/Spec/zimbra-store.deb
@@ -5,4 +5,4 @@ Maintainer: build@zimbra.com
 Section: Mail
 Priority: optional
 Architecture: @@ARCH@@
-Depends: zimbra-core, zimbra-store-components, zimbra-jetty-distribution (>= 9.4.18.v20190429-2.@@PKG_OS_TAG@@)@@MORE_DEPENDS@@
+Depends: zimbra-core, zimbra-store-components, zimbra-jetty-distribution (>= 9.4.46.v20220331-2.@@PKG_OS_TAG@@)@@MORE_DEPENDS@@

--- a/rpmconf/Spec/zimbra-store.spec
+++ b/rpmconf/Spec/zimbra-store.spec
@@ -12,7 +12,7 @@ Vendor: Zimbra, Inc.
 Packager: Zimbra, Inc.
 BuildRoot: /opt/zimbra
 AutoReqProv: no
-requires: zimbra-core, zimbra-store-components, zimbra-jetty-distribution >= 9.4.18.v20190429-2.@@PKG_OS_TAG@@@@MORE_DEPENDS@@
+requires: zimbra-core, zimbra-store-components, zimbra-jetty-distribution >= 9.4.46.v20220331-2.@@PKG_OS_TAG@@@@MORE_DEPENDS@@
 
 %description
 Best email money can buy


### PR DESCRIPTION
Upgrade jetty to 9.4.46.v20220331

Related PR's:
https://github.com/Zimbra/zm-zcs-lib/pull/92
https://github.com/Zimbra/zm-jetty-conf/pull/18
https://github.com/Zimbra/zm-mailbox/pull/1267
