### PR TITLE
ZCS-11697 StoreType colume should get created while installing fresh build

### DIFF
--- a/rpmconf/Upgrade/zmupgrade.pm
+++ b/rpmconf/Upgrade/zmupgrade.pm
@@ -90,6 +90,7 @@ my %updateScripts = (
   '111' => "migrate20210506-BriefcaseApi.pl",          #9.1.0
   '112' => "migrate20200625-MobileDevices.pl",         #Zimbra X
   '113' => "migrate20210319-MobileDevices.pl",         #Zimbra X
+  '114' => "migrate20220525-Volume.pl",                #9.1.0
 );
 
 my %updateFuncs = (
@@ -2136,7 +2137,7 @@ sub upgrade8811GA {
 
 sub upgrade8812GA {
    print "applying 8812GA upgrade changes\n";
-   
+
    print "Updating to CA certs path\n";
 
   qx($su "zmlocalconfig -e mailboxd_truststore=/opt/zimbra/common/lib/jvm/java/lib/security/cacerts");
@@ -2146,7 +2147,7 @@ sub upgrade8812GA {
 
 sub upgrade8815GA {
    print "applying 8815GA upgrade changes\n";
-   
+
    print "Updating OWASP LC config\n";
 
   main::deleteLocalConfig("zimbra_use_owasp_html_sanitizer");


### PR DESCRIPTION
Problem Statement:
Store Type column should get creating while installing fresh ZIMBRA build (not upgrading)

Solution:
Added store_type column entry in volume table for database

Please review this along with https://github.com/Zimbra/zm-db-conf/pull/26
