### PR TITLE
ZCS-11772 : Remove zimbra-modern-ui when removing zimbra webapp

### DIFF
--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -2471,12 +2471,26 @@ isOnlyofficeStandalone() {
 
 }
 
+removeModernUI(){
+	isInstalled zimbra-modern-ui
+	if [ x$PKGINSTALLED != "x" ]; then
+		echo -n "Removing zimbra-modern-ui..."
+		$PACKAGERM zimbra-modern-ui >/dev/null 2>&1
+		echo "done"
+	fi
+}
 deleteWebApp() {
   WEBAPPNAME=$1
   CONTAINERDIR=$2
 
   /bin/rm -rf /opt/zimbra/$CONTAINERDIR/webapps/$WEBAPPNAME
   /bin/rm -rf /opt/zimbra/$CONTAINERDIR/webapps/$WEBAPPNAME.war
+  if [ $WEBAPPNAME == "zimbra" ]; then
+     #zimbra-modern-ui package needs to re-install
+     #because deleting /opt/zimbra/jetty/webapps/zimbra/ will remove modern directory from webapps
+     #so first uninstall zimbra-modern-ui to install it
+     removeModernUI
+  fi
 }
 
 setInstallPackages() {


### PR DESCRIPTION
**Problem :** Modern UI option not present after upgrading to 10.0.0 from 9.0
Upgrade will remove /opt/zimbra/jetty/webapps/zimbra/ , this leads to remove modern directory from webapps and Modern UI option not present after upgrading to 10.0.0.

Upgrade will install zimbra-modern-ui but zimbra-modern-ui package version is same for 10.0.0 , 9.0 . So it will try to install, but it found it is already installed.
**From install log:** Package zimbra-modern-ui-4.27.0.1657193707-1.r8.x86_64 is already installed.

**Fix:** we need to uninstall zimbra-modern-ui while removing /opt/zimbra/jetty/webapps/zimbra/ , so upgrade script will install zimbra-modern-ui.

