### PR TITLE
ZCS-11980 : Fix regexp to get correct build versions

### DIFF
--- a/rpmconf/Upgrade/zmupgrade.pm
+++ b/rpmconf/Upgrade/zmupgrade.pm
@@ -215,8 +215,8 @@ sub upgrade {
        $isLdapMaster = 0;
   }
   my ($startBuild,$targetBuild);
-  ($startVersion,$startBuild) = $startVersion =~ /(\d+\.\d\.\d+_[^_]*)_(\d+)/;
-  ($targetVersion,$targetBuild) = $targetVersion =~ m/(\d+\.\d\.\d+_[^_]*)_(\d+)/;
+  ($startVersion,$startBuild) = $startVersion =~ /(\d+\.\d+\.\d+_[^_]*)_(\d+)/;
+  ($targetVersion,$targetBuild) = $targetVersion =~ m/(\d+\.\d+\.\d+_[^_]*)_(\d+)/;
   ($startMajor,$startMinor,$startMicro) =
     $startVersion =~ /(\d+)\.(\d+)\.(\d+_[^_]*)/;
   ($targetMajor,$targetMinor,$targetMicro) =

--- a/rpmconf/Upgrade/zmupgrade.pm
+++ b/rpmconf/Upgrade/zmupgrade.pm
@@ -215,8 +215,8 @@ sub upgrade {
        $isLdapMaster = 0;
   }
   my ($startBuild,$targetBuild);
-  ($startVersion,$startBuild) = $startVersion =~ /(\d\.\d\.\d+_[^_]*)_(\d+)/;
-  ($targetVersion,$targetBuild) = $targetVersion =~ m/(\d\.\d\.\d+_[^_]*)_(\d+)/;
+  ($startVersion,$startBuild) = $startVersion =~ /(\d+\.\d\.\d+_[^_]*)_(\d+)/;
+  ($targetVersion,$targetBuild) = $targetVersion =~ m/(\d+\.\d\.\d+_[^_]*)_(\d+)/;
   ($startMajor,$startMinor,$startMicro) =
     $startVersion =~ /(\d+)\.(\d+)\.(\d+_[^_]*)/;
   ($targetMajor,$targetMinor,$targetMicro) =


### PR DESCRIPTION
Upgrade from 10.0.0 BETA to latest BETA not allowed. User should be able to upgrade 10.0 from old version to latest BETA version.


Restoring existing configuration file from /opt/zimbra/.saveconfig/localconfig.xml...done
Installing /opt/zimbra/conf/ZCSLicense.xml
Operations logged to /tmp/zmsetup.20220817-121323.log
Adding /opt/zimbra/conf/ca/ca.pem to cacerts
Upgrading from 10.0.0_BETA_4401 to 10.0.0_BETA_4404
ERROR: Upgrading from a ZCS version less than 7.0.0_GA is not supported
UPGRADE FAILED - exiting.