### PR TITLE
ZCS-12028 : Default option for Install chat and video features is No

### DIFF
--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -2465,7 +2465,7 @@ selectImmail() {
 		if [ "${INSTD_IMMAIL_PACKAGES}" -eq 3 ]; then
 			INSTALL_PACKAGES="$INSTALL_PACKAGES $IMMAIL_PACKAGES"
 		else
-			askYN "Install chat and video features" "Y"
+			askYN "Install chat and video features" "N"
 			if [ $response = "yes" ]; then
 				INSTALL_PACKAGES="$INSTALL_PACKAGES $IMMAIL_PACKAGES"
 			fi


### PR DESCRIPTION
Default option for hosted immail chat/video package installation should be No.
Install chat and video features - Set default as N instead of Y