### PR TITLE
ZCS-12041 : Start mysql if not running before create onlyofficeDB

### DIFF
--- a/rpmconf/Install/zmsetup.pl
+++ b/rpmconf/Install/zmsetup.pl
@@ -7412,6 +7412,7 @@ sub configureOnlyoffice {
           qx(chown zimbra:zimbra /opt/zimbra/onlyoffice/bin/process_id.json);
 
           # on new install
+          if (zmupgrade::startSql()) { return 1; }
           createOnlyofficeDB();
           # configure onlyoffice
           print "Configuring Onlyoffice...\n";


### PR DESCRIPTION
**Problem:**
Creating onlyoffice database is failed due to mysql is not running
Mon Aug 22 08:18:52 2022 Creating onlyoffice database...
Mon Aug 22 08:18:52 2022 *** Running as zimbra user: exec /opt/zimbra/common/bin/mysql -S /opt/zimbra/data/tmp/mysql/mysql.sock -u root --password=b7_FcA41SG.xVi1rAhP6kf6aoTwj3ovA < /opt/zimbra/onlyoffice/bin/createdb.sql
ERROR 2002 (HY000): Can't connect to local MySQL server through socket '/opt/zimbra/data/tmp/mysql/mysql.sock' (2 "No such file or directory")
Mon Aug 22 08:18:52 2022 done.