### PR TITLE
ZCS-12029: remove LC dependancy of onlyoffice formatter usage with adding check for zimbraDocumentServerHost

### DIFF
--- a/rpmconf/Install/zmsetup.pl
+++ b/rpmconf/Install/zmsetup.pl
@@ -7397,7 +7397,6 @@ sub configureOnlyoffice {
     # create onlyoffice db and configure it
   if (isEnabled("zimbra-onlyoffice") ) {
     #enable preview
-    setLocalConfig ("oo_linux_install_path", "onlyoffice");
     setLdapCOSConfig("zimbraFeatureViewInHTMLEnabled", "TRUE");
 
     if ($configStatus{configOnlyoffice} eq "CONFIGURED") {


### PR DESCRIPTION
**Issue**
On a multinode setup where onlyoffice package is not installed, extension does not gets initialized causing the preview to be used from convertd as the LC **oo_linux_install_path** is not having updated to onlyoffice.

**Fix**
During multionode setup if the mailbox is not having onlyoffice installation and is being installed as standalone, onlyoffice formatter will be registered since the check from formatter registration of onlyoffice will happen at run time during formatter resolving. Extension will get initialzed and formatter will register. 
During the formatter resolving, it will be checked if there is any standalone onlyoffice installation available from **zimbraDocumentServerHost** ldap attr. If the attr is set then the formatter will be resolved to onlyoffice.

https://github.com/Zimbra/zm-mailbox/pull/1384
https://github.com/Zimbra/zm-doc-server-ext/pull/12