### PR TITLE
ZCS-12128 : Add a pre-upgrade check to detect NG modules installation

### DIFF
--- a/rpmconf/Install/install.sh
+++ b/rpmconf/Install/install.sh
@@ -40,6 +40,7 @@ UNINSTALL="no"
 SOFTWAREONLY="no"
 SKIP_ACTIVATION_CHECK="no"
 SKIP_UPGRADE_CHECK="no"
+SKIP_NG_CHECK="no"
 ALLOW_PLATFORM_OVERRIDE="no"
 FORCE_UPGRADE="no"
 
@@ -57,6 +58,7 @@ usage() {
   echo "--platform-override     Allows installer to continue on an unknown OS."
   echo "--skip-activation-check Allows installer to continue if license activation checks fail."
   echo "--skip-upgrade-check    Allows installer to skip upgrade validation checks."
+  echo "--skip-ng-check         Allows installer to upgrade by removing NG modules and related data."
   echo "--force-upgrade         Force upgrade to be set to YES. Used if there is package installation failure for remote packages."
   echo "[defaultsfile]          File containing default install values."
   echo ""
@@ -117,6 +119,9 @@ while [ $# -ne 0 ]; do
       ;;
     -skip-upgrade-check|--skip-upgrade-check)
       SKIP_UPGRADE_CHECK="yes"
+      ;;
+    -skip-ng-check|--skip-ng-check)
+      SKIP_NG_CHECK="yes"
       ;;
     -force-upgrade|--force-upgrade)
       FORCE_UPGRADE="yes"


### PR DESCRIPTION
- As an admin, when upgrading NG server to Z-10, I should get a warning about presence of NG modules and the upgrade should be aborted. I should be able to use --skip-ng-check option and continue the upgrade.
- Installer should detect if NG is installed or not. If its not installed then the upgrade should continue.
- If NG is installed Abort the upgrade.
- Display this error on screen in RED color.
 `NG Modules detected on your system. If you continue with this upgrade, NG module packages and the data will be deleted.
If you want to preserve NG data, consider using migration or rolling upgrade strategy for upgrading your system. For more information, please contact Zimbra Support.
If you still want to continue, start installation using --skip-ng-check.`

- If admin provides *--skip-ng-check* option, the upgrade should then continue without any warnings