### PR TITLE
ZCS-12164 Change permission of nginx log files

### DIFF
--- a/rpmconf/Spec/Scripts/zimbra-ldap.post
+++ b/rpmconf/Spec/Scripts/zimbra-ldap.post
@@ -26,8 +26,10 @@ chown -R zimbra:zimbra /opt/zimbra/data/ldap
 
 chown -R root:root /opt/zimbra/common/etc/openldap
 
-chown root:zimbra /opt/zimbra/common/libexec/slapd
-chmod 750 /opt/zimbra/common/libexec/slapd
+if [ -x /opt/zimbra/common/libexec/slapd ]; then
+    chown root:zimbra /opt/zimbra/common/libexec/slapd
+    chmod 750 /opt/zimbra/common/libexec/slapd
 
-echo "Set capability for /opt/zimbra/common/libexec/slapd"
-setcap CAP_NET_BIND_SERVICE=+ep /opt/zimbra/common/libexec/slapd
+    echo "Set capability for /opt/zimbra/common/libexec/slapd"
+    setcap CAP_NET_BIND_SERVICE=+ep /opt/zimbra/common/libexec/slapd
+fi

--- a/rpmconf/Spec/Scripts/zimbra-proxy.post
+++ b/rpmconf/Spec/Scripts/zimbra-proxy.post
@@ -18,8 +18,21 @@
 
 chown -R zimbra:zimbra /opt/zimbra/conf/nginx
 
-chown root:zimbra /opt/zimbra/common/sbin/nginx
-chmod 750 /opt/zimbra/common/sbin/nginx
+if [ -f /opt/zimbra/log/nginx.log ]; then
+    chown zimbra:zimbra /opt/zimbra/log/nginx.log
+    chmod 644 /opt/zimbra/log/nginx.log
+fi
 
-echo "Set capability for /opt/zimbra/common/sbin/nginx"
-setcap CAP_NET_BIND_SERVICE=+ep /opt/zimbra/common/sbin/nginx
+if [ -f /opt/zimbra/log/nginx.access.log ]; then
+    chown zimbra:zimbra /opt/zimbra/log/nginx.access.log
+    chmod 644 /opt/zimbra/log/nginx.access.log
+fi
+
+if [ -x /opt/zimbra/common/sbin/nginx ]; then
+    chown root:zimbra /opt/zimbra/common/sbin/nginx
+    chmod 750 /opt/zimbra/common/sbin/nginx
+
+    echo "Set capability for /opt/zimbra/common/sbin/nginx"
+    setcap CAP_NET_BIND_SERVICE=+ep /opt/zimbra/common/sbin/nginx
+fi
+


### PR DESCRIPTION
- After upgrade proxy is not starting as log files are created with root permission
- issue is only happening in server where log rotation has not run once, as log rotation updates file permissions with zimbra user

Related PR https://github.com/Zimbra/zm-core-utils/pull/127