### PR TITLE
ZCS-12219 : Skip NGModules check for uninstall Zimbra

### DIFF
--- a/rpmconf/Install/Util/globals.sh
+++ b/rpmconf/Install/Util/globals.sh
@@ -46,8 +46,7 @@ IMMAIL_PACKAGES="zimbra-zimlet-immail-classic \
 zimbra-zimlet-immail-modern \
 zimbra-extension-immail"
 
-ZEXTRAS_PACKAGES="zimbra-zimlet-briefcase-edit-lool \
-zimbra-connect \
+ZEXTRAS_PACKAGES="zimbra-connect \
 zimbra-connect-modern \
 zimbra-drive \
 zimbra-drive-ng \
@@ -57,6 +56,7 @@ zimbra-docs-modern \
 zimbra-chat \
 zimbra-talk \
 zimbra-zimlet-auth \
+zimbra-zimlet-briefcase-edit-lool \
 zimbra-network-modules-ng"
 
 DEPRECATED_PACKAGES_IN_10="zimbra-zimlet-restore-contacts \

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -929,7 +929,7 @@ verifyUpgrade() {
 }
 
 verifyNGModulesInstalled() {
-	if [ x"$SKIP_NG_CHECK" = "xyes" ]; then
+	if [ x"$SKIP_NG_CHECK" = "xyes" ] || [ x"$UNINSTALL" = "xyes" ]; then
 		return
 	fi
 	NG_INSTALLED="no"

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -2444,7 +2444,9 @@ getInstallPackages() {
     fi
 
   done
-  selectImmail
+  if [ x"$ZMTYPE_INSTALLABLE" = "xNETWORK" ]; then
+     selectImmail
+  fi
   checkRequiredSpace
 
   isInstalled zimbra-store


### PR DESCRIPTION
**Issue 1:**
Skip NGModules check for uninstall Zimbra

**Issue 2:**
FOSS Build should not ask to install immail

**Issue 3:**
Change in order of ze-extras packages remove.
zimbra-zimlet-briefcase-edit-lool package should be remove after zimbra-drive-modern, zimbra-docs-modern packages remove. Because zimbra-drive-modern, zimbra-docs-modern are depends on zimbra-zimlet-briefcase-edit-lool.
