### PR TITLE
ZBUG-2974 Exclude .git directories from build

### DIFF
--- a/instructions/FOSS_staging_list.pl
+++ b/instructions/FOSS_staging_list.pl
@@ -182,7 +182,7 @@
       "dir"         => "zm-help",
       "ant_targets" => undef,
       "stage_cmd"   => sub {
-         SysExec("cp -f -r ../zm-help $CFG{BUILD_DIR}");
+         SysExec("(cd .. && rsync -az --relative --exclude '.git' zm-help $CFG{BUILD_DIR}/)");
       },
    },
    {
@@ -210,7 +210,7 @@
       "dir"         => "zm-downloads",
       "ant_targets" => undef,
       "stage_cmd"   => sub {
-         SysExec("cp -f -r ../zm-downloads $CFG{BUILD_DIR}");
+         SysExec("(cd .. && rsync -az --relative --exclude '.git' zm-downloads $CFG{BUILD_DIR}/)");
       },
    },
    {


### PR DESCRIPTION
- zm-help and zm-downloads repos doesn't have any ant target for creating artifacts
- and zm-build repo just copies all files from above repos to include it as part of final build
- but in this inclusion zm-build is using cp command which copies .git directories as well
- so we are excluding .git directories when copying data and creating build