### PR TITLE
ZCS-2733 Removed product help pages from the build

### DIFF
--- a/instructions/FOSS_repo_list.pl
+++ b/instructions/FOSS_repo_list.pl
@@ -23,7 +23,6 @@
    { name => "zm-dnscache",                          },
    { name => "zm-downloads",                         },
    { name => "zm-freshclam",                         },
-   { name => "zm-help",                              },
    { name => "zm-helptooltip-zimlet",                },
    { name => "zm-jetty-conf",                        },
    { name => "zm-jython",                            },

--- a/instructions/FOSS_staging_list.pl
+++ b/instructions/FOSS_staging_list.pl
@@ -171,13 +171,6 @@
       "deploy_pkg_into" => "bundle",
    },
    {
-      "dir"         => "zm-help",
-      "ant_targets" => undef,
-      "stage_cmd"   => sub {
-         SysExec("(cd .. && rsync -az --relative --exclude '.git' zm-help $CFG{BUILD_DIR}/)");
-      },
-   },
-   {
       "dir"         => "zm-admin-help-common",
       "ant_targets" => undef,
       "stage_cmd"   => sub {

--- a/instructions/bundling-scripts/zimbra-store.sh
+++ b/instructions/bundling-scripts/zimbra-store.sh
@@ -155,9 +155,6 @@ main()
       mkdir -p ${repoDir}/zm-build/${currentPackage}/opt/zimbra/jetty_base/webapps/zimbra/public
     fi
 
-    echo "\t\t***** help content *****" >> ${buildLogFile}
-    cp -rf ${repoDir}/zm-help/. ${repoDir}/zm-build/${currentPackage}/opt/zimbra/jetty_base/webapps/zimbra/help
-
     echo "\t\t***** portals example content *****" >> ${buildLogFile}
     mkdir -p ${repoDir}/zm-build/${currentPackage}/opt/zimbra/jetty_base/webapps/zimbra/portals/example
     cp -rf ${repoDir}/zm-webclient-portal-example/example ${repoDir}/zm-build/${currentPackage}/opt/zimbra/jetty_base/webapps/zimbra/portals


### PR DESCRIPTION
Removing the default inclusion of product help pages present in zm-help repository from the build. The product help pages can be installed explicitly by using the "zimbra-help" package ([PR link](https://github.com/Zimbra/zm-help/pull/5)).