### PR TITLE
ZCS-13761 : Install zimbra-ldap-patch

### DIFF
--- a/rpmconf/Install/install.sh
+++ b/rpmconf/Install/install.sh
@@ -325,6 +325,17 @@ if [ $SOFTWAREONLY = "yes" ]; then
 	exit 0
 fi
 
+# Install the zimbra-ldap-patch
+isInstalled zimbra-ldap
+if [ x$PKGINSTALLED != "x" ]; then
+        echo "Installing zimbra-ldap-patch"
+        $REPOINST zimbra-ldap-patch >>$LOGFILE 2>&1
+        if [ $? -ne 0 ]; then
+                echo "Failed to install zimbra-ldap-patch"
+                exit 1
+        fi
+fi
+
 #
 # Installation complete, now configure
 #


### PR DESCRIPTION
**Problem :** Unable to install the standalone LDAP server with 8.8.15.p41, 9.0.0.p34

```
Running as zimbra user: /opt/zimbra/bin/zmcertmgr deploycrt self

Installing imapd certificate '/opt/zimbra/conf/imapd.crt' and key '/opt/zimbra/conf/imapd.key'
Copying '/opt/zimbra/ssl/zimbra/server/server.crt' to '/opt/zimbra/conf/imapd.crt'
Copying '/opt/zimbra/ssl/zimbra/server/server.key' to '/opt/zimbra/conf/imapd.key'
Creating file '/opt/zimbra/ssl/zimbra/jetty.pkcs12'
ERROR: openssl pkcs12 export to '/opt/zimbra/ssl/zimbra/jetty.pkcs12' failed(1):
Error creating PKCS12 MAC; no PKCS12KDF support?
Use -nomac if MAC not required and PKCS12KDF support not available.
8072E5DFDE7F0000:error:0308010C:digital envelope routines:inner_evp_generic_fetch:unsupported:crypto/evp/evp_fetch.c:373:Global default library context, Algorithm (PKCS12KDF : 192), Properties (<null>)
8072E5DFDE7F0000:error:1180006B:PKCS12 routines:pkcs12_gen_mac:key gen error:crypto/pkcs12/p12_mutl.c:147:
8072E5DFDE7F0000:error:1180006D:PKCS12 routines:PKCS12_set_mac:mac generation error:crypto/pkcs12/p12_mutl.c:220:
Tue Aug 1 19:22:41 2023 failed.
```

To fix this issue we have updated zmcertmgr in the zimbra-ldap-patch but ZCS 8.8.15/9.0 won’t not install zimbra-ldap-patch in fresh setup.  So updating install.sh to install zimbra-ldap-patch