### PR TITLE
ZCS-13806: Added rclone command to download network build dependencies from zimbra third party server.

### DIFF
--- a/instructions/bundling-scripts/zimbra-store.sh
+++ b/instructions/bundling-scripts/zimbra-store.sh
@@ -171,7 +171,9 @@ main()
     then
         set -e
         cd ${downloadsDir}
-        wget -r -nd --no-parent --reject-regex="/backup/" --reject "index.*" http://${zimbraThirdPartyServer}/ZimbraThirdParty/zco-migration-builds/current/
+        # wget -r -nd --no-parent --reject-regex="/backup/" --reject "index.*" http://${zimbraThirdPartyServer}/ZimbraThirdParty/zco-migration-builds/current/
+        # zimbraThirdPartyServer Could be S3 bucket name.
+        rclone copy -v ${zimbraThirdPartyServer}/ZimbraThirdParty/zco-migration-builds/current/ ./
     fi
 
     echo "\t\t***** help content *****" >> ${buildLogFile}


### PR DESCRIPTION
**ZCS-13806: Added rclone command to download network build dependencies from zimbra third party server.**
- Currently `zdev-**** . ***.zimbra.com` is used as a `BUILD_THIRDPARTY_SERVER / zimbraBuildThirdParty` server
- Since this server is on Synacor VPN, some build dependencies are downloaded from this server directly with `wget` by making sure the the build environment is connected to the Synacor VPN.

**Fix implemented**
- Replaced the `wget` command with `rclone` command.
- Rclone is a tool to connect with an object-storage / s3 bucket to download / upload files.
- We need to make sure that the build environment has the correct rclone config with secret key and access id of the corresponding s3 bucket. 
- Then we can use rclone command to download dependencies like follows -
```
rclone --config /path/to/config cp <source> <destination>
```

**Important notes**
- If approved and merged - we need to make sure to cherry-pick these changes on all tags (8 / 9 / 10)