### PR TITLE
ZCS-14060 : updated zmsetup.pl,install.sh according to new licensing

### DIFF
--- a/rpmconf/Install/install.sh
+++ b/rpmconf/Install/install.sh
@@ -48,7 +48,6 @@ usage() {
   echo "$0 [-r <dir> -l <file> -a <file> -u -s -c type -x -h] [defaultsfile]"
   echo ""
   echo "-h|--help               Usage"
-  echo "-l|--license <file>     License file to install."
   echo "-a|--activation <file>  License activation file to install. [Upgrades only]"
   echo "-r|--restore <dir>      Restore contents of <dir> to localconfig"
   echo "-s|--softwareonly       Software only installation."
@@ -70,20 +69,6 @@ while [ $# -ne 0 ]; do
     -r|--restore|--config)
       shift
       RESTORECONFIG=$1
-      ;;
-    -l|--license)
-      shift
-      LICENSE=$1
-      if [ x"$LICENSE" = "x" ]; then
-        echo "Valid license file required for -l."
-        usage
-      fi
-
-      if [ ! -f "$LICENSE" ]; then
-        echo "Valid license file required for -l."
-        echo "${LICENSE}: file not found."
-        usage
-      fi
       ;;
     -a|--activation)
       shift
@@ -158,14 +143,6 @@ else
 	AUTOINSTALL="no"
 fi
 
-if [ x"$LICENSE" != "x" ] && [ -e $LICENSE ]; then
-  if [ ! -d "/opt/zimbra/conf" ]; then
-    mkdir -p /opt/zimbra/conf
-  fi
-  cp $LICENSE /opt/zimbra/conf/ZCSLicense.xml
-  chown zimbra:zimbra /opt/zimbra/conf/ZCSLicense.xml 2> /dev/null
-  chmod 444 /opt/zimbra/conf/ZCSLicense.xml
-fi
 
 if [ x"$ACTIVATION" != "x" ] && [ -e $ACTIVATION ]; then
   if [ ! -d "/opt/zimbra/conf" ]; then

--- a/rpmconf/Install/zmsetup.pl
+++ b/rpmconf/Install/zmsetup.pl
@@ -2674,7 +2674,7 @@ sub setLicenseCode {
 
 sub setLicenseActivationChoice {
   while (1) {
-    my $choice = askNum("Please select one option (1. Activate license with installation 2. Activate license after installation)",$config{LICENSEACTIVATIONCHOICE});
+    my $choice = askNum("Please select one option 1. Activate license with installation 2. Activate license after installation",$config{LICENSEACTIVATIONCHOICE});
     if ($choice eq "1") {
 	    $config{LICENSEACTIVATIONCHOICE} = $choice;
 	    setLicenseCode();
@@ -2682,7 +2682,7 @@ sub setLicenseActivationChoice {
     }
     if ($choice eq "2") {
 	    $config{LICENSEACTIVATIONCHOICE} = $choice;
-	    print "Activate license after installation using zmlincese -a {license code here} \n";
+	    print "Activate license after installation using zmlicense -a {license code here} \n";
 	    return;
     }
     print "Please enter a valid option!\n";


### PR DESCRIPTION
Changed the script to use license code instead of license XML file.
No need to pass license code to the installer.sh script.

**Requirements:**
Under the zimbra-store menu, add a new option - License Activation

When the admin chooses zimbra-store, under Store Configuration, a new option License Activation should be added at the end of the menu.

When the admin chooses this option, he should get 2 options:

1. Activate license with installation
2. Activate license after installation

The prompt to enter the option should appear like this:

- Select, or 'r' for previous menu [r] 

If the admin selects option 1 - Activate license with installation, he should be presented with a prompt to enter the License Key:

- Please enter the license key (enter 'r' for previous menu) :
- If the admin provides a valid license key, the installation moves to next step.
- If the admin enters r, he should be sent back to the previous menu of License Activation.
- If the admin provides an invalid license key, show him an error message - Invalid license key entered. The license key should be an alphanumeric string of 18-24 characters.
- The license should be activated at the end of the Zimbra installation and a message should be displayed on the screen and logged in the log file on successful activation - LIcense successfully activated
- In case the license activation fails at the end of the Zimbra installation, an error should be displayed on the screen and logged in the log file, and the installation process should be halted (Existing behavior) - Display the existing message

If the admin selects option 2 - Activate license after installation, then no further actions should be done related to licensing and the installer should proceed with the next steps.

- A message should be displayed on the screen after selecting the option - After the successful installation, use zmlicense -a <licensekey> to activate license key or contact support team for an offline activation file.

Once the admin selects the option and is back at the Store Configuration and zimbra-store, the License Activation option should be updated with the option the user selected. For e.g., if user selects option 2, the following should be displayed:

- License Activation:                        Activate license after installation

If the admin chooses to change the selected option, the flow will be the same. 

If the admin previously selected Activate license with installation and updated the license key but wants to change the license key, display the previously entered license key on the final prompt:

- Please enter the license key (enter 'r' for previous menu) [Previously entered license key here]:

Here we are targeting this only for fresh installation and not for the upgrade path.

https://github.com/Zimbra/zm-network-build/pull/26
