### PR TITLE
ZCS-14205:Fix License is not getting activated while fresh installation

### DIFF
--- a/rpmconf/Install/zmsetup.pl
+++ b/rpmconf/Install/zmsetup.pl
@@ -7889,7 +7889,7 @@ sub activateLicense {
 		progress ("Looking for valid license to activate...");
 		my $licensekey = $config{LICENSEKEY};
 		my $rc = runAsZimbra("/opt/zimbra/bin/zmlicense -c");
-		if ($rc == 256) {
+		if ($rc == 256 || $rc == 512) {
 			my $lic = 1;
 			if ($licensekey ne "") {
 				$rc = runAsZimbra("/opt/zimbra/bin/zmlicense -a $licensekey");


### PR DESCRIPTION
**Issue :** License is not getting activated while installing the EA Build but manually using zmlicense -a it is getting activated. Below are the installation logs: 

```
Tue Nov  7 07:47:29 2023 done.
Tue Nov  7 07:47:29 2023 checking isEnabled zimbra-store
Tue Nov  7 07:47:29 2023 zimbra-store is enabled
Tue Nov  7 07:47:29 2023 Looking for valid license to activate...
Tue Nov  7 07:47:29 2023 *** Running as zimbra user: /opt/zimbra/bin/zmlicense -c
checking license status. . .
Tue Nov  7 07:47:34 2023 license already activated.
Tue Nov  7 07:47:34 2023 checking isEnabled zimbra-store
Tue Nov  7 07:47:34 2023 zimbra-store is enabled
Tue Nov  7 07:47:34 2023 Enabling jetty logging...
Tue Nov  7 07:47:34 2023 done.
```
Fix : added check to validate https://github.com/Zimbra/zm-license-tools/blob/develop/src/java/com/zimbra/cs/license/LicenseCLI.java#L127