### PR TITLE
ZCS-13984 : Changes for RHEL9

### DIFF
--- a/rpmconf/Build/get_plat_tag.sh
+++ b/rpmconf/Build/get_plat_tag.sh
@@ -25,6 +25,11 @@ if [ -f /etc/redhat-release ]; then
     i=""
   fi
 
+  grep "Red Hat Enterprise Linux.*release 9" /etc/redhat-release > /dev/null 2>&1
+  if [ $? = 0 ]; then
+    echo "RHEL9${i}"
+    exit 0
+  fi
   grep "Red Hat Enterprise Linux.*release 8" /etc/redhat-release > /dev/null 2>&1
   if [ $? = 0 ]; then
     echo "RHEL8${i}"
@@ -41,6 +46,11 @@ if [ -f /etc/redhat-release ]; then
     exit 0
   fi
 
+  grep "CentOS Linux release 9" /etc/redhat-release > /dev/null 2>&1
+  if [ $? = 0 ]; then
+    echo "RHEL9${i}"
+    exit 0
+  fi
   grep "CentOS Linux release 8" /etc/redhat-release > /dev/null 2>&1
   if [ $? = 0 ]; then
     echo "RHEL8${i}"
@@ -57,12 +67,22 @@ if [ -f /etc/redhat-release ]; then
     exit 0
   fi
 
+  grep "Rocky Linux release 9" /etc/redhat-release > /dev/null 2>&1
+  if [ $? = 0 ]; then
+    echo "RHEL9${i}"
+    exit 0
+  fi
   grep "Rocky Linux release 8" /etc/redhat-release > /dev/null 2>&1
   if [ $? = 0 ]; then
     echo "RHEL8${i}"
     exit 0
   fi
 
+  grep "Scientific Linux release 9" /etc/redhat-release > /dev/null 2>&1
+  if [ $? = 0 ]; then
+    echo "RHEL9${i}"
+    exit 0
+  fi
   grep "Scientific Linux release 8" /etc/redhat-release > /dev/null 2>&1
   if [ $? = 0 ]; then
     echo "RHEL8${i}"

--- a/rpmconf/Install/Util/modules/packages.sh
+++ b/rpmconf/Install/Util/modules/packages.sh
@@ -143,6 +143,7 @@ installPackages() {
    fi
 
    removeExistingInstall
+   installEPELRepo
 
    if [ "${#repo_pkg_names[@]}" -gt 0 ]
    then

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -2507,6 +2507,7 @@ getInstallPackages() {
   if [ x"$ZMTYPE_INSTALLABLE" = "xNETWORK" ]; then
      selectChatVideo
   fi
+  isp7zipRequired
   checkRequiredSpace
 
   isInstalled zimbra-store
@@ -2525,6 +2526,83 @@ getInstallPackages() {
   done
 }
 
+isp7zipRequired() {
+	P7ZIPREQUIRED=no
+	if [[ $MTA_SELECTED == "yes" && $PLATFORM = "RHEL9_64" ]]; then
+		isInstalled p7zip-plugins
+		if [ x$PKGINSTALLED = "x" ]; then
+			askYN "Install p7zip-plugins from epel-release repository (without p7zip-plugins, some decoders for Amavis may not be available)." "Y"
+			if [ $response = "yes" ]; then
+				P7ZIPREQUIRED=yes
+			fi
+		fi
+	fi
+}
+
+installEPELRepo() {
+	if [ $P7ZIPREQUIRED = "yes" ]; then
+		OS_NAME=`grep -E '^(NAME)=' /etc/os-release | cut -d = -f 2 | tr -d '"'`
+		case "$OS_NAME" in
+			"Red Hat"*)
+				isInstalled epel-release-latest-9
+				if [ x$PKGINSTALLED = "x" ]; then
+					echo -n "Installing epel-release-latest-9..."
+					if ! yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm -y >>$LOGFILE 2>&1 ; then
+						echo "failed to install epel-release."
+						exit 1
+					else
+						echo "done."
+					fi
+				fi
+				echo -n "Installing p7zip-plugins..."
+				if ! yum install p7zip-plugins --enablerepo=epel -y >>$LOGFILE 2>&1 ; then
+					echo "failed to install p7zip-plugins."
+					exit 1
+				else
+					echo "done."
+				fi
+				;;
+			"Oracle"*)
+				isInstalled oracle-epel-release-el9
+				if [ x$PKGINSTALLED = "x" ]; then
+					echo -n "Installing oracle-epel-release-el9..."
+					if ! yum install oracle-epel-release-el9 -y >>$LOGFILE 2>&1 ; then
+						echo "failed to install epel-release."
+						exit 1
+					else
+						echo "done."
+					fi
+				fi
+				echo -n "Installing p7zip-plugins..."
+				if ! yum install p7zip-plugins --enablerepo=ol9_developer_EPEL -y >>$LOGFILE 2>&1 ; then
+					echo "failed to install p7zip-plugins."
+					exit 1
+				else
+					echo "done."
+				fi
+				;;
+			"Rocky"*|"CentOS"*)
+				isInstalled epel-release
+				if [ x$PKGINSTALLED = "x" ]; then
+					echo -n "Installing epel-release..."
+					if ! yum install epel-release -y > /dev/null >>$LOGFILE 2>&1 ; then
+						echo "failed to install epel-release."
+						exit 1
+					else
+						echo "done."
+					fi
+				fi
+				echo -n "Installing p7zip-plugins..."
+				if ! yum install p7zip-plugins --enablerepo=epel -y >>$LOGFILE 2>&1; then
+					echo "failed to install p7zip-plugins."
+					exit 1
+				else
+					echo "done."
+				fi
+				;;
+		esac
+	fi
+}
 selectChatVideo() {
 	# install chat-video extension and chat-video classic, modern zimlets
 	if [ $STORE_SELECTED = "yes" ] ; then

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -1903,7 +1903,7 @@ removeExistingInstall() {
             if [ $? = 0 ]; then
               echo -n "Cleaning up /etc/rsyslog.conf..."
               sed -i -e '/zimbra/d' /etc/rsyslog.conf
-              if [ $PLATFORM = "RHEL6_64" -o $PLATFORM = "RHEL7_64" -o $PLATFORM = "RHEL8_64" ]; then
+              if [ $PLATFORM = "RHEL6_64" -o $PLATFORM = "RHEL7_64" -o $PLATFORM = "RHEL8_64" -o $PLATFORM = "RHEL9_64" ]; then
                 sed -i -e 's/^*.info;local0.none;local1.none;mail.none;auth.none/*.info/' /etc/rsyslog.conf
                 sed -i -e 's/^*.info;local0.none;local1.none;auth.none/*.info/' /etc/rsyslog.conf
               fi
@@ -2211,6 +2211,8 @@ fi
         repo="rhel7"
      elif [ $PLATFORM = "RHEL8_64" ]; then
         repo="rhel8"
+     elif [ $PLATFORM = "RHEL9_64" ]; then
+	repo="rhel9"
       else
         print "Aborting, unknown platform: $PLATFORM"
         exit 1
@@ -2905,7 +2907,7 @@ getPlatformVars() {
       if [ $PLATFORM = "RHEL6_64" ]; then
          STORE_PACKAGES="libreoffice libreoffice-headless"
       fi
-      if [ $PLATFORM = "RHEL7_64" -o $PLATFORM = "RHEL8_64" ]; then
+      if [ $PLATFORM = "RHEL7_64" -o $PLATFORM = "RHEL8_64" -o $PLATFORM = "RHEL9_64" ]; then
          STORE_PACKAGES="libreoffice libreoffice-core"
       fi
       DumpFileDetailsFromPackage() {

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -2217,10 +2217,18 @@ fi
         print "Aborting, unknown platform: $PLATFORM"
         exit 1
       fi
-      rpm -q gpg-pubkey-0f30c305-5564be70 > /dev/null
+      if [ $PLATFORM = "RHEL9_64" ]; then
+	      rpm -q gpg-pubkey-7c66bd84-6583eafa > /dev/null
+      else
+	      rpm -q gpg-pubkey-0f30c305-5564be70 > /dev/null
+      fi
       if [ $? -ne 0 ]; then
         echo "Importing Zimbra GPG key"
-        rpm --import https://files.zimbra.com/downloads/security/public.key >>$LOGFILE 2>&1
+	if [ $PLATFORM = "RHEL9_64" ]; then
+		rpm --import https://files.zimbra.com/downloads/security/public-sha-256.key >>$LOGFILE 2>&1
+	else
+		rpm --import https://files.zimbra.com/downloads/security/public.key >>$LOGFILE 2>&1
+	fi
         if [ $? -ne 0 ]; then
           echo "ERROR: Unable to retrive Zimbra GPG key for package validation"
           echo "Please fix system to allow normal package installation before proceeding"

--- a/rpmconf/Spec/zimbra-imapd.spec
+++ b/rpmconf/Spec/zimbra-imapd.spec
@@ -19,6 +19,11 @@ Best email money can buy
 
 %define __spec_install_pre /bin/true
 
+%if 0%{?rhel} == 9
+%define __brp_ldconfig RPM_BUILD_ROOT="" /usr/lib/rpm/redhat/brp-ldconfig
+%define __brp_mangle_shebangs RPM_BUILD_ROOT="" /usr/lib/rpm/redhat/brp-mangle-shebangs
+%endif
+
 %prep
 
 %build

--- a/rpmconf/Spec/zimbra-spell.spec
+++ b/rpmconf/Spec/zimbra-spell.spec
@@ -19,6 +19,11 @@ Best email money can buy
 
 %define __spec_install_pre /bin/true
 
+%if 0%{?rhel} == 9
+%define __brp_ldconfig RPM_BUILD_ROOT="" /usr/lib/rpm/redhat/brp-ldconfig
+%define __brp_mangle_shebangs RPM_BUILD_ROOT="" /usr/lib/rpm/redhat/brp-mangle-shebangs
+%endif
+
 %prep
 
 %build

--- a/rpmconf/Spec/zimbra-store.spec
+++ b/rpmconf/Spec/zimbra-store.spec
@@ -19,6 +19,11 @@ Best email money can buy
 
 %define __spec_install_pre /bin/true
 
+%if 0%{?rhel} == 9
+%define __brp_ldconfig RPM_BUILD_ROOT="" /usr/lib/rpm/redhat/brp-ldconfig
+%define __brp_mangle_shebangs RPM_BUILD_ROOT="" /usr/lib/rpm/redhat/brp-mangle-shebangs
+%endif
+
 %prep
 
 %build


### PR DESCRIPTION
For zimbra-imapd, zimbra-spell, zimbra-store packages getting below error.
```
/usr/lib/rpm/redhat/brp-ldconfig: line 5: RPM_BUILD_ROOT: unbound variable
/usr/lib/rpm/redhat/brp-mangle-shebangs: line 4: RPM_BUILD_ROOT: unbound variable
```
`RPM_BUILD_ROOT` is not defined. 

`/usr/lib/rpm/redhat/brp-ldconfig` and `/usr/lib/rpm/redhat/brp-mangle-shebangs` are changed in the RHEL9.
 To fix this issue from build side, we need to define `RPM_BUILD_ROOT`.