### PR TITLE
ZCS-14464:Install p7zip-plugins from EPEL repo for RHEL9

### DIFF
--- a/rpmconf/Install/Util/modules/packages.sh
+++ b/rpmconf/Install/Util/modules/packages.sh
@@ -143,6 +143,7 @@ installPackages() {
    fi
 
    removeExistingInstall
+   installEPELRepo
 
    if [ "${#repo_pkg_names[@]}" -gt 0 ]
    then


### PR DESCRIPTION
**Issue :** pax/spax  package not available with default RHEL 9 repo

- pax/spax package is required for amavisd.
- pax/spax  package not available with default RHEL 9 repo. It is present on some third-party repo which is not secured/recommended . 
- We have to replace it with 7zip/p7zip-plugins which is also not available in default repo but 7zip/p7zip-plugins is present in the EPEL repo.

**Fix:** Added prompt to install script to install EPEL repo or not. Install p7zip-plugins from EPEL repo. 