### PR TITLE
ZCS-14744 : Update license activation validation API

### DIFF
--- a/rpmconf/Build/checkLicense.pl
+++ b/rpmconf/Build/checkLicense.pl
@@ -115,12 +115,13 @@ if ( $response->is_success ) {
 	my $json_content = $response->content;
 	my ($status_code) = $json_content =~ /"status":\s*(\d+)/;
 	if (defined $status_code && $status_code == 2000) {
-		myDie(0,"SUCCESS: ", $response->content, "\n");
+		myDie(0, "SUCCESS: ", $response->content, "\n");
 	} else {
-		myDie(1,"ERROR: ", $response->content, "\n");
+		myDie(1, "ERROR: ", $response->content, "\n");
+
 	}
 } else {
-	myDie(1,"ERROR: ", $response->content, "\n");
+	myDie(1, "ERROR: ", $response->content, "\n");
 }
 
 sub myDie() {

--- a/rpmconf/Build/checkLicense.pl
+++ b/rpmconf/Build/checkLicense.pl
@@ -16,14 +16,27 @@
 # ***** END LICENSE BLOCK *****
 #
 use strict;
+
 use lib qw(/opt/zimbra/common/lib/perl5 /opt/zimbra/zimbramon/lib);
 use LWP::UserAgent;
 use Getopt::Long;
 use Net::LDAP;
 use XML::Simple;
 
+# License key validation function
+sub valid_licenseID {
+    my ($licenseID) = @_;
+    return $licenseID =~ /^[A-Za-z0-9]{18,24}$/;
+}
+
+# Set permissions function
+sub set_permissions {
+    my ($file) = @_;
+    system("chown zimbra:zimbra $file");
+    system("chmod 644 $file");
+}
 my %options;
-my ( $licenseId, @license, $blah, $host );
+my ( $licenseId, $blah, $host );
 
 GetOptions( \%options, "version=s", "internal", "help" ) or usage();
 
@@ -80,7 +93,7 @@ $mesg = $ldap->search(
     base   => "cn=config,cn=zimbra",
     filter => "(zimbraNetworkLicense=*)",
     scope  => "base",
-    attrs  => [ 'zimbraNetworkLicense'],
+    attrs  => [ 'zimbraRealtimeNetworkLicense'],
 );
 
 my $size = $mesg->count;
@@ -90,25 +103,29 @@ if ( $size == 0 ) {
 }
 
 my $entry           = $mesg->entry(0);
-my $license = $entry->get_value("zimbraNetworkLicense");
-if (defined $license) {
-    eval {
-        my $licensexml = XMLin($license);
-        if (exists $licensexml->{item}->{LicenseId}->{value}) {
-            $licenseId = $licensexml->{item}->{LicenseId}->{value};
-        } else {
-            $licenseId = $license;
+my $licenseID = $entry->get_value("zimbraRealtimeNetworkLicense");
+# Check if licenseID is empty
+if (!defined($licenseID) || $licenseID eq '') {
+    my $license_file = "/opt/zimbra/conf/ZCSLicensekey";
+    if (-e $license_file) {
+        chomp($licenseID = qx(cat $license_file));
+    } else {
+        print "Enter the licenseID (an alphanumeric string of 18-24 characters without any special characters): ";
+        $licenseID = <STDIN>;
+        chomp($licenseID);
+        if (!valid_licenseID($licenseID)) {
+	    myDie(2,"Error: Invalid licenseID entered. The licenseID should be an alphanumeric string of 18-24 characters without any special characters\n");
         }
-    };
-    if ($@) {
-        $licenseId = $license;
+        system("echo \"$licenseID\" > $license_file");
+        set_permissions($license_file);
     }
 }
 my $caf = '/opt/zimbra/zimbramon/lib/Mozilla/CA/cacert.pem';
 my @lwpargs = -f $caf ? ( ssl_opts => { SSL_ca_file => $caf, SSL_ca_path => undef } ) : ();
 my $browser = LWP::UserAgent->new(@lwpargs);
 $browser->env_proxy;
-my $request = HTTP::Request->new(POST => "$host/rest/v1/public/license/$licenseId/validate?version=$options{version}");
+print "licenseID is $licenseID \n";
+my $request = HTTP::Request->new(POST => "$host/rest/v1/public/license/$licenseID/validate?version=$options{version}");
 $request->header('Content-Type' => 'application/json');
 my $response = $browser->request($request);
 if ( $response->is_success ) {

--- a/rpmconf/Build/checkLicense.pl
+++ b/rpmconf/Build/checkLicense.pl
@@ -119,6 +119,10 @@ if (!defined($licenseID) || $licenseID eq '') {
         system("echo \"$licenseID\" > $license_file");
         set_permissions($license_file);
     }
+} else {
+	if (-e $license_file) {
+		chomp($licenseID = qx(cat $license_file));
+	}
 }
 my $caf = '/opt/zimbra/zimbramon/lib/Mozilla/CA/cacert.pem';
 my @lwpargs = -f $caf ? ( ssl_opts => { SSL_ca_file => $caf, SSL_ca_path => undef } ) : ();

--- a/rpmconf/Build/checkLicense.pl
+++ b/rpmconf/Build/checkLicense.pl
@@ -23,28 +23,48 @@ use Getopt::Long;
 use Net::LDAP;
 use XML::Simple;
 
-# License key validation function
-sub valid_licenseID {
-    my ($licenseID) = @_;
-    return $licenseID =~ /^[A-Za-z0-9]{18,24}$/;
+sub valid_licensekey {
+	my ($licensekey) = @_;
+	return $licensekey =~ /^[A-Za-z0-9]{18,24}$/;
 }
 
-# Set permissions function
 sub set_permissions {
-    my ($file) = @_;
-    system("chown zimbra:zimbra $file");
-    system("chmod 644 $file");
+	my ($file) = @_;
+	system("chown zimbra:zimbra $file");
+	system("chmod 644 $file");
+}
+
+sub compare_versions {
+	my ($version1, $version2) = @_;
+	my @v1 = split /\./, $version1;
+	my @v2 = split /\./, $version2;
+	for my $i (0 .. $#v1) {
+		return -1 if !defined $v2[$i];
+		return 1  if $v1[$i] > $v2[$i];
+		return -1 if $v1[$i] < $v2[$i];
+	}
+	return 0 if @v1 == @v2;
+	return 1 if @v1 > @v2;
+	return -1;
 }
 my %options;
-my ( $licenseId, $blah, $host );
+my ( $licensekey, $blah, $host );
 
-GetOptions( \%options, "version=s", "internal", "help" ) or usage();
+GetOptions(
+	\%options,
+	"upgradeVersion|uv=s",
+	"currentVersion|cv=s",
+	"internal",
+	"help"
+) or usage();
 
 sub usage {
     print(
-        "usage: checkLicense.pl -v VERSION [-i]\n",
-        "\t-v VERSION: Example: -v 8.7.0\n",
-        "\t-i: Internal Zimbra usage\n"
+        "usage: checkLicense.pl -uv UPGRADEVERSION -cv CURRENTVERSION [-i]\n",
+        "\t-uv UPGRADEVERSION: Example: -uv 8.7.0\n",
+        "\t-cv CURRENTVERSION: Example: -cv 8.6.0\n",
+        "\t-i: Internal Zimbra usage\n",
+        "\t-h: Display this help message\n"
     );
     exit(0);
 }
@@ -60,8 +80,8 @@ else {
     $host = 'https://license.zimbra.com';
 }
 
-unless ( $options{version} ) {
-    myDie(3,"ERROR: No upgrade version supplied.\n");
+unless ( $options{upgradeVersion} && $options{currentVersion} ) {
+    myDie(3,"ERROR: Both upgrade version and current version must be supplied.\n");
 }
 
 my $localxml              = XMLin("/opt/zimbra/conf/localconfig.xml");
@@ -91,52 +111,51 @@ $mesg = $ldap->bind( "$zimbra_admin_dn", password => "$zimbra_admin_password" );
 $mesg->code && myDie(6,"Bind: ", $mesg->error, "\n");
 $mesg = $ldap->search(
     base   => "cn=config,cn=zimbra",
-    filter => "(zimbraNetworkLicense=*)",
+    filter => "(zimbraNetworkRealtimeLicense=*)",
     scope  => "base",
-    attrs  => [ 'zimbraRealtimeNetworkLicense'],
+    attrs  => [ 'zimbraNetworkRealtimeLicense'],
 );
 
 my $size = $mesg->count;
-if ( $size == 0 ) {
-    $ldap->unbind();
-    myDie(2,"Error: License not found\n");
+if (compare_versions($options{currentVersion}, '10.1.0') >= 0 && $size == 0) {
+	$ldap->unbind();
+	myDie(2,"Error: license key not found\n");
 }
 
 my $entry           = $mesg->entry(0);
-my $licenseID = $entry->get_value("zimbraRealtimeNetworkLicense");
-# Check if licenseID is empty
-if (!defined($licenseID) || $licenseID eq '') {
-    my $license_file = "/opt/zimbra/conf/ZCSLicensekey";
-    if (-e $license_file) {
-        chomp($licenseID = qx(cat $license_file));
-    } else {
-        print "Enter the licenseID (an alphanumeric string of 18-24 characters without any special characters): ";
-        $licenseID = <STDIN>;
-        chomp($licenseID);
-        if (!valid_licenseID($licenseID)) {
-	    myDie(2,"Error: Invalid licenseID entered. The licenseID should be an alphanumeric string of 18-24 characters without any special characters\n");
-        }
-        system("echo \"$licenseID\" > $license_file");
-        set_permissions($license_file);
-    }
-} else {
+my $licensekey = "";
+if ($entry) {
+	$licensekey = $entry->get_value("zimbraNetworkRealtimeLicense");
+}
+if (!defined($licensekey) || $licensekey eq '') {
+	my $license_file = "/opt/zimbra/conf/ZCSLicensekey";
 	if (-e $license_file) {
-		chomp($licenseID = qx(cat $license_file));
+		chomp($licensekey = qx(cat $license_file));
+	} else {
+		print "\n";
+		print "Please enter the license key (an alphanumeric string of 18-24 characters without any special characters):";
+		$licensekey = <STDIN>;
+		chomp($licensekey);
+		if (!valid_licensekey($licensekey)) {
+			myDie(7,"Error: Invalid license key entered \n");
+		}
+		system("echo \"$licensekey\" > $license_file");
+		set_permissions($license_file);
 	}
 }
 my $caf = '/opt/zimbra/zimbramon/lib/Mozilla/CA/cacert.pem';
 my @lwpargs = -f $caf ? ( ssl_opts => { SSL_ca_file => $caf, SSL_ca_path => undef } ) : ();
 my $browser = LWP::UserAgent->new(@lwpargs);
 $browser->env_proxy;
-print "licenseID is $licenseID \n";
-my $request = HTTP::Request->new(POST => "$host/rest/v1/public/license/$licenseID/validate?version=$options{version}");
+my $request = HTTP::Request->new(POST => "$host/rest/v1/public/license/$licensekey/validate?version=$options{upgradeVersion}");
 $request->header('Content-Type' => 'application/json');
 my $response = $browser->request($request);
 if ( $response->is_success ) {
 	my $json_content = $response->content;
 	my ($status_code) = $json_content =~ /"status":\s*(\d+)/;
 	if (defined $status_code && $status_code == 2000) {
-		myDie(0, "SUCCESS: ", $response->content, "\n");
+		my ($status_message) = $json_content =~ /"statusMessage":\s*"([^"]*)"/;
+		myDie(0, "SUCCESS: ", $status_message, "\n");
 	} else {
 		myDie(1, "ERROR: ", $response->content, "\n");
 

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -850,10 +850,10 @@ verifyUpgrade() {
           echo $HOSTNAME | egrep -qe 'eng.vmware.com$|eng.zimbra.com$|lab.zimbra.com$|zimbradev.com$' > /dev/null 2>&1
           if [ $? = 0 ]; then
             # echo "Running bin/checkLicense.pl -i -v $ZM_INST_VERSION"
-            `bin/checkLicense.pl -i -v $ZM_INST_VERSION >/dev/null`
+              bin/checkLicense.pl -v $ZM_INST_VERSION
           else
             # echo "Running bin/checkLicense.pl -v $ZM_INST_VERSION"
-            `bin/checkLicense.pl -v $ZM_INST_VERSION >/dev/null`
+              bin/checkLicense.pl -v $ZM_INST_VERSION
           fi
           licenseRC=$?;
           if [ $licenseRC != 0 ]; then
@@ -970,17 +970,6 @@ verifyLicenseActivationServer() {
     return
   fi
 
-  # if we specify an activation presume its valid
-  if [ x"$ACTIVATION" != "x" ] && [ -e $ACTIVATION ]; then
-    if [ ! -d "/opt/zimbra/conf" ]; then
-      mkdir -p /opt/zimbra/conf
-    fi
-    cp -f $ACTIVATION /opt/zimbra/conf/ZCSLicense-activated.xml
-    chown zimbra:zimbra /opt/zimbra/conf/ZCSLicense-activated.xml
-    chmod 444 /opt/zimbra/conf/ZCSLicense-activated.xml
-    return
-  fi
-
   # if all else fails make sure we can contact the activation server for automated activation
   if [ ${ZM_CUR_MAJOR} -ge "7" ]; then
     if [ ${ZM_CUR_MAJOR} -eq "7" -a ${ZM_CUR_MINOR} -ge "1" ]; then
@@ -1052,15 +1041,6 @@ activationWarning() {
 }
 
 verifyLicenseAvailable() {
-
-  if [ x"$LICENSE" != "x" ] && [ -e $LICENSE ]; then
-    if [ ! -d "/opt/zimbra/conf" ]; then
-      mkdir -p /opt/zimbra/conf
-    fi
-    cp -f $LICENSE /opt/zimbra/conf/ZCSLicense.xml
-    chown zimbra:zimbra /opt/zimbra/conf/ZCSLicense.xml 2> /dev/null
-    chmod 444 /opt/zimbra/conf/ZCSLicense.xml
-  fi
 
   if [ x"$AUTOINSTALL" = "xyes" ] || [ x"$UNINSTALL" = "xyes" ] || [ x"$SOFTWAREONLY" = "xyes" ]; then
     return

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -854,7 +854,7 @@ verifyUpgrade() {
           echo "Validating whether an existing license is expired or not and checking if it qualifies for an upgrade"
           echo $HOSTNAME | egrep -qe 'eng.vmware.com$|eng.zimbra.com$|lab.zimbra.com$|zimbradev.com$' > /dev/null 2>&1
           if [ $? = 0 ]; then
-              bin/checkLicense.pl -uv $ZM_INST_VERSION -cv $ZM_CUR_VERSION
+              bin/checkLicense.pl -i -uv $ZM_INST_VERSION -cv $ZM_CUR_VERSION
           else
               bin/checkLicense.pl -uv $ZM_INST_VERSION -cv $ZM_CUR_VERSION
           fi

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -840,20 +840,23 @@ verifyUpgrade() {
   fi
 
   isInstalled "zimbra-ldap"
-  if [ x$PKGINSTALLED != "x" ]; then
-    runAsZimbra "ldap start"
+  LDAP_INSTALLED=$PKGINSTALLED
+  if [ "x$LDAP_INSTALLED" != "x" ]; then
+	  runAsZimbra "ldap start"
+  fi
+  isInstalled "zimbra-store"
+  STORE_INSTALLED=$PKGINSTALLED
+  if [ "x$LDAP_INSTALLED" != "x" ] || [ "x$STORE_INSTALLED" != "x" ]; then
     # Upgrade tests specific to NE only
     if [ x"$ZMTYPE_CURRENT" = "xNETWORK" ] && [ x"$ZMTYPE_INSTALLABLE" = "xNETWORK" ]; then
       if [ x"$SKIP_ACTIVATION_CHECK" = "xno" ]; then
         if [ -x "bin/checkLicense.pl" ]; then
-          echo "Validating existing license is not expired and qualifies for upgrade"
+          echo "Validating whether an existing license is expired or not and checking if it qualifies for an upgrade"
           echo $HOSTNAME | egrep -qe 'eng.vmware.com$|eng.zimbra.com$|lab.zimbra.com$|zimbradev.com$' > /dev/null 2>&1
           if [ $? = 0 ]; then
-            # echo "Running bin/checkLicense.pl -i -v $ZM_INST_VERSION"
-              bin/checkLicense.pl -v $ZM_INST_VERSION
+              bin/checkLicense.pl -uv $ZM_INST_VERSION -cv $ZM_CUR_VERSION
           else
-            # echo "Running bin/checkLicense.pl -v $ZM_INST_VERSION"
-              bin/checkLicense.pl -v $ZM_INST_VERSION
+              bin/checkLicense.pl -uv $ZM_INST_VERSION -cv $ZM_CUR_VERSION
           fi
           licenseRC=$?;
           if [ $licenseRC != 0 ]; then
@@ -870,10 +873,13 @@ verifyUpgrade() {
               echo "Error: No upgrade version supplied"
               exit 1
             elif [ $licenseRC = 2 ]; then
-              echo "Error: No license file found"
+              echo "Error: license key not found"
               exit 1
+            elif [ $licenseRC = 7 ]; then
+              echo "Error: The license key should be an alphanumeric string of 18-24 characters without any special characters"
+	      exit 1
             elif [ $licenseRC = 1 ]; then
-              echo "Error: License is expired or cannot be upgraded."
+              echo "Error: License is expired or not authorized for upgrade or cannot be upgraded."
               echo "       Aborting upgrade"
               exit 1
             else
@@ -1056,7 +1062,7 @@ verifyLicenseAvailable() {
      return
   fi
 
-  echo "Checking for available license file..."
+  echo "Checking for available license..."
 
 
   # use the tool if it exists

--- a/rpmconf/Install/install.sh
+++ b/rpmconf/Install/install.sh
@@ -45,10 +45,10 @@ ALLOW_PLATFORM_OVERRIDE="no"
 FORCE_UPGRADE="no"
 
 usage() {
-  echo "$0 [-r <dir> -l <file> -a <file> -u -s -c type -x -h] [defaultsfile]"
+  echo "$0 [-r <dir> -l <licensekey> -u -s -c type -x -h] [defaultsfile]"
   echo ""
   echo "-h|--help               Usage"
-  echo "-a|--activation <file>  License activation file to install. [Upgrades only]"
+  echo "-l|--licensekey         License key to install."
   echo "-r|--restore <dir>      Restore contents of <dir> to localconfig"
   echo "-s|--softwareonly       Software only installation."
   echo "-u|--uninstall          Uninstall ZCS"
@@ -64,25 +64,26 @@ usage() {
   exit
 }
 
+validate_license_key() {
+    local new="$1"
+    if [[ ! "$new" =~ ^[A-Za-z0-9]+$ ]] || (( ${#new} < 18 )) || (( ${#new} > 24 )) || [[ -z "$new" ]]; then
+	echo "Invalid license key entered. The license key should be a non-blank alphanumeric string of 18-24 characters without any special characters!"
+        usage
+    fi
+}
+
+
 while [ $# -ne 0 ]; do
   case $1 in
     -r|--restore|--config)
       shift
       RESTORECONFIG=$1
       ;;
-    -a|--activation)
+    -l|--licensekey)
       shift
-      ACTIVATION=$1
-      if [ x"$ACTIVATION" = "x" ]; then
-        echo "Valid license activation file required for -a."
-        usage
-      fi
-
-      if [ ! -f "$ACTIVATION" ]; then
-        echo "Valid license activation file required for -a."
-        echo "${ACTIVATION}: file not found."
-        usage
-      fi
+      LICENSEKEY=$1
+      validate_license_key $LICENSEKEY
+      echo LICENSEKEY is $LICENSEKEY
       ;;
     -u|--uninstall)
       UNINSTALL="yes"
@@ -143,22 +144,17 @@ else
 	AUTOINSTALL="no"
 fi
 
-
-if [ x"$ACTIVATION" != "x" ] && [ -e $ACTIVATION ]; then
+if [ "x$LICENSEKEY" != "x" ] ; then
+  echo "Installing /opt/zimbra/conf/ZCSLicensekey"
   if [ ! -d "/opt/zimbra/conf" ]; then
     mkdir -p /opt/zimbra/conf
   fi
-  cp $ACTIVATION /opt/zimbra/conf/ZCSLicense-activated.xml
-  chown zimbra:zimbra /opt/zimbra/conf/ZCSLicense-activated.xml 2> /dev/null
-  chmod 444 /opt/zimbra/conf/ZCSLicense-activated.xml
+  echo "$LICENSEKEY" > /opt/zimbra/conf/ZCSLicensekey
+  chown zimbra:zimbra /opt/zimbra/conf/ZCSLicensekey
+  chmod 644 /opt/zimbra/conf/ZCSLicensekey
 fi
 
 checkExistingInstall
-
-if [ x"$INSTALLED" != "xyes" ] && [ x"$ACTIVATION" != "x" ]; then
-  echo "License activation file option is only available on upgrade."
-  usage
-fi
 
 if [ x$UNINSTALL = "xyes" ]; then
 	askYN "Completely remove existing installation?" "N"
@@ -274,23 +270,14 @@ if [ $UPGRADE = "yes" ]; then
   #restoreZimlets
 fi
 
-if [ "x$LICENSE" != "x" ] && [ -f "$LICENSE" ]; then
-  echo "Installing /opt/zimbra/conf/ZCSLicense.xml"
+if [ "x$LICENSEKEY" != "x" ] ; then
+  echo "Installing /opt/zimbra/conf/ZCSLicensekey"
   if [ ! -d "/opt/zimbra/conf" ]; then
     mkdir -p /opt/zimbra/conf
   fi
-  cp -f $LICENSE /opt/zimbra/conf/ZCSLicense.xml
-  chown zimbra:zimbra /opt/zimbra/conf/ZCSLicense.xml
-  chmod 644 /opt/zimbra/conf/ZCSLicense.xml
-fi
-if [ "x$ACTIVATION" != "x" ] && [ -f "$ACTIVATION" ]; then
-  echo "Installing /opt/zimbra/conf/ZCSLicense.xml"
-  if [ ! -d "/opt/zimbra/conf" ]; then
-    mkdir -p /opt/zimbra/conf
-  fi
-  cp -f $ACTIVATION /opt/zimbra/conf/ZCSLicense-activated.xml
-  chown zimbra:zimbra /opt/zimbra/conf/ZCSLicense-activated.xml
-  chmod 644 /opt/zimbra/conf/ZCSLicense-activated.xml
+  echo "$LICENSEKEY" > /opt/zimbra/conf/ZCSLicensekey
+  chown zimbra:zimbra /opt/zimbra/conf/ZCSLicensekey
+  chmod 644 /opt/zimbra/conf/ZCSLicensekey
 fi
 
 

--- a/rpmconf/Install/install.sh
+++ b/rpmconf/Install/install.sh
@@ -83,7 +83,6 @@ while [ $# -ne 0 ]; do
       shift
       LICENSEKEY=$1
       validateLicensekey $LICENSEKEY
-      echo LICENSEKEY is $LICENSEKEY
       ;;
     -u|--uninstall)
       UNINSTALL="yes"
@@ -137,9 +136,19 @@ chmod 750 $SAVEDIR
 
 echo ""
 echo "Operations logged to $LOGFILE"
-if [ -e "/opt/zimbra/conf/ZCSLicensekey" ]; then
-	rm -f /opt/zimbra/conf/ZCSLicensekey
-fi
+
+licensefiles=(
+    "/opt/zimbra/conf/ZCSLicense.xml"
+    "/opt/zimbra/conf/ZCSLicense-Trial.xml"
+    "/opt/zimbra/conf/ZCSLicense-activated.xml"
+    "/opt/zimbra/conf/ZCSLicensekey"
+)
+
+for file in "${licensefiles[@]}"; do
+    if [[ -e "$file" ]]; then
+        rm -f "$file"
+    fi
+done
 
 if [ "x$DEFAULTFILE" != "x" ]; then
 	AUTOINSTALL="yes"
@@ -148,7 +157,6 @@ else
 fi
 
 if [ "x$LICENSEKEY" != "x" ] ; then
-  echo "Installing /opt/zimbra/conf/ZCSLicensekey"
   if [ ! -d "/opt/zimbra/conf" ]; then
     mkdir -p /opt/zimbra/conf
   fi
@@ -274,7 +282,6 @@ if [ $UPGRADE = "yes" ]; then
 fi
 
 if [ "x$LICENSEKEY" != "x" ] ; then
-  echo "Installing /opt/zimbra/conf/ZCSLicensekey"
   if [ ! -d "/opt/zimbra/conf" ]; then
     mkdir -p /opt/zimbra/conf
   fi

--- a/rpmconf/Install/install.sh
+++ b/rpmconf/Install/install.sh
@@ -64,7 +64,7 @@ usage() {
   exit
 }
 
-validate_license_key() {
+validateLicensekey() {
     local new="$1"
     if [[ ! "$new" =~ ^[A-Za-z0-9]+$ ]] || (( ${#new} < 18 )) || (( ${#new} > 24 )) || [[ -z "$new" ]]; then
 	echo "Invalid license key entered. The license key should be a non-blank alphanumeric string of 18-24 characters without any special characters!"
@@ -82,7 +82,7 @@ while [ $# -ne 0 ]; do
     -l|--licensekey)
       shift
       LICENSEKEY=$1
-      validate_license_key $LICENSEKEY
+      validateLicensekey $LICENSEKEY
       echo LICENSEKEY is $LICENSEKEY
       ;;
     -u|--uninstall)
@@ -137,6 +137,9 @@ chmod 750 $SAVEDIR
 
 echo ""
 echo "Operations logged to $LOGFILE"
+if [ -e "/opt/zimbra/conf/ZCSLicensekey" ]; then
+	rm -f /opt/zimbra/conf/ZCSLicensekey
+fi
 
 if [ "x$DEFAULTFILE" != "x" ]; then
 	AUTOINSTALL="yes"

--- a/rpmconf/Install/zmsetup.pl
+++ b/rpmconf/Install/zmsetup.pl
@@ -7413,7 +7413,7 @@ sub applyConfig {
     runAsZimbra ("/opt/zimbra/bin/zmcontrol start");
     qx($SU "/opt/zimbra/bin/zmcontrol status");
     progress ( "done.\n" );
-	activateLicense();
+    activateLicense();
 
     # Initialize application server specific items
     # only after the application server is running.

--- a/rpmconf/Install/zmsetup.pl
+++ b/rpmconf/Install/zmsetup.pl
@@ -2691,7 +2691,7 @@ sub chooseLicenseActivationOption {
 					return;
 				}
 				if ($choice eq "2") {
-					system("rm -rf $license_file");
+					system("rm -rf $license_file") if -e $license_file;
 					$config{LICENSEACTIVATIONOPTION} = $choice;
 					print "After the successful installation, use zmlicense -a <licensekey> to activate license key or contact support team for an offline activation file \n";
 					return;
@@ -3559,7 +3559,11 @@ sub isFoss {
 }
 
 sub isLicenseActivated {
- return(runAsZimbra("/opt/zimbra/bin/zmlicense -c") ? 0 : 1);
+	my $licenseDaemonConfigured = isEnabled("zimbra-license-daemon") && -d "/opt/zimbra/license";
+	runAsZimbra("/opt/zimbra/bin/zmlicensectl --service restart") if $licenseDaemonConfigured && !$newinstall;
+	my $status = runAsZimbra("/opt/zimbra/bin/zmlicense -c") ? 0 : 1;
+	runAsZimbra("/opt/zimbra/bin/zmlicensectl --service stop") if $licenseDaemonConfigured && !$newinstall;
+	return $status;
 }
 
 sub createPackageMenu {
@@ -4506,9 +4510,8 @@ sub createStoreMenu {
     } else {
 	    $config{LICENSEACTIVATIONOPTIONMSG} = "UNSET";
     }
-    # only prompt for license if we are network install and
-    # a license not activated
-    if (isNetwork() && !isLicenseActivated() ) {
+    # only prompt for license if we are network install and a license not activated
+    if (isNetwork() && !isLicenseActivated()) {
 	    $$lm{menuitems}{$i} = {
 		    "prompt" => "License Activation:",
 		    "var" => \$config{LICENSEACTIVATIONOPTIONMSG},
@@ -7414,6 +7417,7 @@ sub applyConfig {
     qx($SU "/opt/zimbra/bin/zmcontrol status");
     progress ( "done.\n" );
     activateLicense();
+    system("rm -rf $license_file") if -e $license_file;
 
     # Initialize application server specific items
     # only after the application server is running.
@@ -7894,39 +7898,14 @@ sub addJDK17Options {
 
 sub activateLicense {
 	if (isNetwork() && isEnabled("zimbra-store")) {
-		if ($config{LICENSEACTIVATIONOPTION} eq "1") {
-			progress ("Looking for valid license to activate...");
-			my $licensekey = $config{LICENSEKEY};
-			my $rc = runAsZimbra("/opt/zimbra/bin/zmlicense -c");
-			if ($rc == 256 || $rc == 512) {
-				my $lic = 1;
-				if ($licensekey ne "") {
-					$rc = runAsZimbra("/opt/zimbra/bin/zmlicense -a $licensekey");
-					if ($rc != 0) {
-						progress ("failed to activate license.\n");
-						$lic = 0;
-					} else {
-						progress ("license successfully activated.\n");
-					}
-				} else {
-					progress ("license key not found.\n");
-				}
-				if ($lic == 0){
-					progress ("\n*******ERROR\n\nFailed to activate a license - this will prevent your server from functioning properly\n");
-					progress ("Please contact Zimbra to obtain a license\n");
-					ask ("Press RETURN to continue","");
-				}
-			} else {
-				progress ("license already activated.\n");
-			}
-		}
 		if (! $newinstall ) {
 			progress ("Activating license...");
-			if (-e $license_file) {
-				chomp($licensekey = qx(cat $license_file));
+			my $licensekey = getLdapConfigValue("zimbraNetworkRealtimeLicense");
+			if ($licensekey eq "") {
+				chomp($licensekey = qx(cat $license_file)) if (-e $license_file);
 			}
 			if ($licensekey ne "") {
-				$rc = runAsZimbra("/opt/zimbra/bin/zmlicense -a $licensekey");
+				my $rc = runAsZimbra("/opt/zimbra/bin/zmlicense -l -a $licensekey");
 				if ($rc != 0) {
 					progress ("failed to activate license.\n");
 				} else {
@@ -7934,6 +7913,33 @@ sub activateLicense {
 				}
 			} else {
 				progress ("license key not found.\n");
+			}
+		} else {
+			if ($config{LICENSEACTIVATIONOPTION} eq "1") {
+				progress ("Looking for valid license to activate...");
+				my $licensekey = $config{LICENSEKEY};
+				my $rc = runAsZimbra("/opt/zimbra/bin/zmlicense -c");
+				if ($rc == 256 || $rc == 512) {
+					my $lic = 1;
+					if ($licensekey ne "") {
+						$rc = runAsZimbra("/opt/zimbra/bin/zmlicense -a $licensekey");
+						if ($rc != 0) {
+							 progress ("failed to activate license.\n");
+							  $lic = 0;
+						} else {
+							progress ("license successfully activated.\n");
+						}
+					} else {
+						progress ("license key not found.\n");
+					}
+					if ($lic == 0){
+						progress ("\n*******ERROR\n\nFailed to activate a license - this will prevent your server from functioning properly\n");
+						progress ("Please contact Zimbra to obtain a license\n");
+						ask ("Press RETURN to continue","");
+					}
+				} else {
+					progress ("license already activated.\n");
+				}
 			}
 		}
 	}

--- a/rpmconf/Install/zmsetup.pl
+++ b/rpmconf/Install/zmsetup.pl
@@ -51,6 +51,7 @@ our $SU = "su - zimbra -c ";
 my $filename="/opt/zimbra/conf/localconfig.xml";
 my $uid = (stat $filename)[4];
 my $user = (getpwuid $uid)[0];
+my $license_file = "/opt/zimbra/conf/ZCSLicensekey";
 
 if ($user ne "zimbra") {
     progress ("\n\nERROR\n\n");
@@ -2675,27 +2676,31 @@ sub setLicenseKey {
 }
 
 sub chooseLicenseActivationOption {
-	while (1) {
-		print "1) Activate license with installation\n";
-		print "2) Activate license after installation\n\n";
-		my $choice = askNonBlank("Select, or 'r' for previous menu","r");
-		if ($choice eq "1") {
-			setLicenseKey();
-			if ($config{LICENSEKEY} ne "") {
-				$config{LICENSEACTIVATIONOPTION} = $choice;
+			while (1) {
+				print "1) Activate license with installation\n";
+				print "2) Activate license after installation\n\n";
+				my $choice = askNonBlank("Select, or 'r' for previous menu","r");
+				if ($choice eq "1") {
+					setLicenseKey();
+					if ($config{LICENSEKEY} ne "") {
+						system("echo \"$config{LICENSEKEY}\" > $license_file");
+						system("chown zimbra:zimbra $license_file");
+						system("chmod 644 $license_file");
+						$config{LICENSEACTIVATIONOPTION} = $choice;
+					}
+					return;
+				}
+				if ($choice eq "2") {
+					system("rm -rf $license_file");
+					$config{LICENSEACTIVATIONOPTION} = $choice;
+					print "After the successful installation, use zmlicense -a <licensekey> to activate license key or contact support team for an offline activation file \n";
+					return;
+				}
+				if ($choice eq "r") {
+					return;
+				}
+				print "Please enter a valid option!\n\n";
 			}
-			return;
-		}
-		if ($choice eq "2") {
-			$config{LICENSEACTIVATIONOPTION} = $choice;
-			print "After the successful installation, use zmlicense -a <licensekey> to activate license key or contact support team for an offline activation file \n";
-			return;
-		}
-		if ($choice eq "r") {
-			return;
-		}
-		print "Please enter a valid option!\n\n";
-	}
 }
 
 
@@ -4490,6 +4495,10 @@ sub createStoreMenu {
       "arg" => "UIWEBAPPS"
     };
     $i++;
+    if (-e $license_file) {
+	    chomp($config{LICENSEKEY} = qx(cat $license_file));
+	    $config{LICENSEACTIVATIONOPTION} = "1";
+    }
     if ($config{LICENSEACTIVATIONOPTION} eq "1") {
 	    $config{LICENSEACTIVATIONOPTIONMSG} = "Activate license with installation";
     } elsif ($config{LICENSEACTIVATIONOPTION} eq "2") {
@@ -4497,7 +4506,6 @@ sub createStoreMenu {
     } else {
 	    $config{LICENSEACTIVATIONOPTIONMSG} = "UNSET";
     }
-
     # only prompt for license if we are network install and
     # a license not activated
     if (isNetwork() && !isLicenseActivated() ) {
@@ -7405,10 +7413,7 @@ sub applyConfig {
     runAsZimbra ("/opt/zimbra/bin/zmcontrol start");
     qx($SU "/opt/zimbra/bin/zmcontrol status");
     progress ( "done.\n" );
-    # Activate license if user selected option 1. Activate license with installation
-    if ($config{LICENSEACTIVATIONOPTION} eq "1") {
-	    activateLicense();
-    }
+	activateLicense();
 
     # Initialize application server specific items
     # only after the application server is running.
@@ -7889,29 +7894,47 @@ sub addJDK17Options {
 
 sub activateLicense {
 	if (isNetwork() && isEnabled("zimbra-store")) {
-		progress ("Looking for valid license to activate...");
-		my $licensekey = $config{LICENSEKEY};
-		my $rc = runAsZimbra("/opt/zimbra/bin/zmlicense -c");
-		if ($rc == 256 || $rc == 512) {
-			my $lic = 1;
+		if ($config{LICENSEACTIVATIONOPTION} eq "1") {
+			progress ("Looking for valid license to activate...");
+			my $licensekey = $config{LICENSEKEY};
+			my $rc = runAsZimbra("/opt/zimbra/bin/zmlicense -c");
+			if ($rc == 256 || $rc == 512) {
+				my $lic = 1;
+				if ($licensekey ne "") {
+					$rc = runAsZimbra("/opt/zimbra/bin/zmlicense -a $licensekey");
+					if ($rc != 0) {
+						progress ("failed to activate license.\n");
+						$lic = 0;
+					} else {
+						progress ("license successfully activated.\n");
+					}
+				} else {
+					progress ("license key not found.\n");
+				}
+				if ($lic == 0){
+					progress ("\n*******ERROR\n\nFailed to activate a license - this will prevent your server from functioning properly\n");
+					progress ("Please contact Zimbra to obtain a license\n");
+					ask ("Press RETURN to continue","");
+				}
+			} else {
+				progress ("license already activated.\n");
+			}
+		}
+		if (! $newinstall ) {
+			progress ("Activating license...");
+			if (-e $license_file) {
+				chomp($licensekey = qx(cat $license_file));
+			}
 			if ($licensekey ne "") {
 				$rc = runAsZimbra("/opt/zimbra/bin/zmlicense -a $licensekey");
 				if ($rc != 0) {
 					progress ("failed to activate license.\n");
-					$lic = 0;
 				} else {
 					progress ("license successfully activated.\n");
 				}
 			} else {
 				progress ("license key not found.\n");
 			}
-			if ($lic == 0){
-				progress ("\n*******ERROR\n\nFailed to activate a license - this will prevent your server from functioning properly\n");
-				progress ("Please contact Zimbra to obtain a license\n");
-				ask ("Press RETURN to continue","");
-			}
-		} else {
-			progress ("license already activated.\n");
 		}
 	}
 }


### PR DESCRIPTION
While upgrading Zimbra there is an activation check executed to check whether the license is valid to use this version, presently upgrade script makes this call to the following API with some GET params.

`https://$host/zimbraLicensePortal/public/activation?action=getActivation&licenseId=$licenseId&version=$options{version}&fingerprint=$fingerprint&activationId=$activationId`
But for the real-time licensing, there is another API that will be used instead

Introducing a new option, `--licenseKey`, which can be passed to the upgrade or install script (./install.sh). This ensures that the licenseCheck is executed for the upgrade component.

Example Usage:
/install.sh --licenseKey xxxxxx4455xx455xxxxx

If the administrator fails to provide the license key, a prompt should be issued during installation.

Deleting below files before upgrade as these are not supported with new license changes.
```
/opt/zimbra/conf/ZCSLicense.xml
/opt/zimbra/conf/ZCSLicense-Trial.xml
/opt/zimbra/conf/ZCSLicense-activated.xml
```
