### PR TITLE
ZCS-15017 : script to manually upgrade the database schema and add option to continue with database errors

### DIFF
--- a/instructions/bundling-scripts/zimbra-core.sh
+++ b/instructions/bundling-scripts/zimbra-core.sh
@@ -516,6 +516,7 @@ main()
    Copy ${repoDir}/zm-db-conf/src/db/migration/migrateToSplitTables.pl                              ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/scripts/migrateToSplitTables.pl
    Copy ${repoDir}/zm-db-conf/src/db/migration/migrateUpdateAppointment.pl                          ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/scripts/migrateUpdateAppointment.pl
    Copy ${repoDir}/zm-db-conf/src/db/migration/optimizeMboxgroups.pl                                ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/scripts/optimizeMboxgroups.pl
+   Copy ${repoDir}/zm-db-conf/src/db/migration/zmdbupgrade.pl                                       ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/scripts/zmdbupgrade.pl
    Copy ${repoDir}/zm-db-conf/src/db/mysql/create_database.sql                                      ${repoDir}/zm-build/${currentPackage}/opt/zimbra/db/create_database.sql
    Copy ${repoDir}/zm-db-conf/src/db/mysql/db.sql                                                   ${repoDir}/zm-build/${currentPackage}/opt/zimbra/db/db.sql
 

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -327,7 +327,10 @@ checkDatabaseIntegrity() {
 					fi
 				fi
 				if [ $MAILBOXDBINTEGRITYSTATUS != 0 ]; then
-					exit $?
+					askYN "Do you want to continue with database errors?" "N"
+					if [ "$response" != "yes" ]; then
+						exit $MAILBOXDBINTEGRITYSTATUS
+					fi
 				fi
 				break
 			done

--- a/rpmconf/Upgrade/zmupgrade.pm
+++ b/rpmconf/Upgrade/zmupgrade.pm
@@ -41,6 +41,9 @@ chomp $rundir;
 my $scriptDir = "/opt/zimbra/libexec/scripts";
 
 my $lowVersion = 52;
+
+# Ensure to update the corresponding value in the zm-db-conf repository,
+# specifically in the file src/db/migration/zmdbupgrade.pl.
 my $hiVersion = 118; # this should be set to the DB version expected by current server code
 
 my $needSlapIndexing = 0;


### PR DESCRIPTION
https://github.com/Zimbra/zm-db-conf/pull/36
adding `zm-db-conf/src/db/migration/zmdbupgrade.pl` to the `/opt/zimbra/libexec/scripts/zmdbupgrade.pl`
and add option to continue with database errors.