### PR TITLE
ZBUG-4003 : copy the install.log file to /opt/zimbra/log/

### DIFF
--- a/rpmconf/Install/Util/globals.sh
+++ b/rpmconf/Install/Util/globals.sh
@@ -17,6 +17,10 @@
 # 
 
 LOGFILE=`mktemp -t install.log.XXXXXXXX 2> /dev/null` || { echo "Failed to create tmpfile"; exit 1; }
+if [ -e "/tmp/install.log" ]; then
+	rm "/tmp/install.log"
+fi
+ln -sf "$LOGFILE" "/tmp/install.log"
 PLATFORM=`bin/get_plat_tag.sh`
 
 CORE_PACKAGES="zimbra-core"

--- a/rpmconf/Install/install.sh
+++ b/rpmconf/Install/install.sh
@@ -313,6 +313,16 @@ if [ $SOFTWAREONLY = "yes" ]; then
 	exit 0
 fi
 
+if [ -e "$LOGFILE" ]; then
+	LOG_DIR="/opt/zimbra/log"
+	if [ ! -d "$LOG_DIR" ]; then
+		mkdir -p "$LOG_DIR"
+		chown zimbra:zimbra "$LOG_DIR"
+	fi
+	echo "Copying $LOGFILE to $LOG_DIR"
+	cp -f $LOGFILE $LOG_DIR/
+	chown zimbra:zimbra "$LOG_DIR/$(basename "$LOGFILE")"
+fi
 #
 # Installation complete, now configure
 #


### PR DESCRIPTION
Running the ZCS installer creates two files (like install.log.XXXXXX and zmsetup.YYYYMMDD-XXXXX.log) inside the /tmp/ directory and copies zmsetup.log to /opt/zimbra/log/ once the installation is completed. 
The installer leaves the install.log file inside the /tmp/ directory, where it is purged by the OS service (tmpfiles-clean). 

The installer must copy the install.log file to /opt/zimbra/log/ in the same manner as it moves zmseutp.log.