### PR TITLE
ZCS-15155 : Change the orphan account message and flow

### DIFF
--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -328,10 +328,12 @@ checkDatabaseIntegrity() {
 					fi
 				fi
 				if [ $MAILBOXDBINTEGRITYSTATUS != 0 ]; then
-					if echo "$MAILBOXDBINTEGRITYOUTPUT" | grep -q "Found mailbox record mismatch"; then
-						echo "Orphan accounts detected. Continuing with the upgrade"
-					else
+					if echo "$MAILBOXDBINTEGRITYOUTPUT" | grep -q "Database errors found" && echo "$MAILBOXDBINTEGRITYOUTPUT" | grep -q "Orphan accounts detected"; then
 						exit $MAILBOXDBINTEGRITYSTATUS
+					elif echo "$MAILBOXDBINTEGRITYOUTPUT" | grep -q "Database errors found"; then
+						exit $MAILBOXDBINTEGRITYSTATUS
+					elif echo "$MAILBOXDBINTEGRITYOUTPUT" | grep -q "Orphan accounts detected"; then
+						echo "Orphan accounts detected. Continuing with the upgrade."
 					fi
 				fi
 				break

--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -311,8 +311,9 @@ checkDatabaseIntegrity() {
 						sleep 2
 					done
 				fi
-				perl bin/zmdbintegrityreport -v -r
+				MAILBOXDBINTEGRITYOUTPUT=$(perl bin/zmdbintegrityreport -v -r 2>&1)
 				MAILBOXDBINTEGRITYSTATUS=$?
+				echo "$MAILBOXDBINTEGRITYOUTPUT"
 				if [ x"$SQLSTARTED" != "x" ]; then
 					su - zimbra -c "/opt/zimbra/bin/mysqladmin -s ping" 2>/dev/null
 					if [ $? = 0 ]; then
@@ -327,8 +328,9 @@ checkDatabaseIntegrity() {
 					fi
 				fi
 				if [ $MAILBOXDBINTEGRITYSTATUS != 0 ]; then
-					askYN "Do you want to continue with database errors?" "N"
-					if [ "$response" != "yes" ]; then
+					if echo "$MAILBOXDBINTEGRITYOUTPUT" | grep -q "Found mailbox record mismatch"; then
+						echo "Orphan accounts detected. Continuing with the upgrade"
+					else
 						exit $MAILBOXDBINTEGRITYSTATUS
 					fi
 				fi


### PR DESCRIPTION
we added a check to identify orphan accounts and prompt the admin to continue or not.

We need to change the flow and message:

- If the orphan accounts are detected, then change the existing message to - “Orphan accounts detected. Continuing with the upgrade"
- Do not prompt the admin and instead continue with the upgrade. 

https://github.com/Zimbra/zm-core-utils/pull/157