### PR TITLE
ZCS-15165 : Fix Onlyoffice start issue and default options for packages during do-release-upgrade from U20 to U22

### DIFF
--- a/rpmconf/Install/Util/utilfunc.sh
+++ b/rpmconf/Install/Util/utilfunc.sh
@@ -660,7 +660,7 @@ checkExistingInstall() {
     isInstalled $i
     if [ x"$PKGINSTALLED" != "x" ]; then
       echo "FOUND $PKGINSTALLED"
-      if [ "$i" != "zimbra-memcached" ]; then
+      if [ "$i" != "zimbra-memcached" ] && [ "$i" != "zimbra-license-daemon" ] && [ "$i" != "zimbra-onlyoffice" ]; then
          INSTALLED="yes"
       fi
       INSTALLED_PACKAGES="$INSTALLED_PACKAGES $i"

--- a/rpmconf/Install/zmsetup.pl
+++ b/rpmconf/Install/zmsetup.pl
@@ -7500,6 +7500,13 @@ sub configureOnlyoffice {
   if (isEnabled("zimbra-onlyoffice") ) {
     #enable preview
     setLdapCOSConfig("zimbraFeatureViewInHTMLEnabled", "TRUE");
+    # configure onlyoffice
+    print "Configuring Onlyoffice...\n";
+    open(my $py, "|-", "/opt/zimbra/onlyoffice/bin/zmonlyofficeconfig");
+    while (<$py>) {
+	     print "$py";
+    }
+    close($py);
 
     if ($configStatus{configOnlyoffice} eq "CONFIGURED") {
       configLog("configOnlyoffice");
@@ -7515,14 +7522,6 @@ sub configureOnlyoffice {
           # on new install
           if (zmupgrade::startSql()) { return 1; }
           createOnlyofficeDB();
-          # configure onlyoffice
-          print "Configuring Onlyoffice...\n";
-
-          open(my $py, "|-", "/opt/zimbra/onlyoffice/bin/zmonlyofficeconfig");
-          while (<$py>) {
-            print "$py";
-          }
-          close($py);
 
           # set the config value zimbraDocumentServerHost
           # if standalone server :


### PR DESCRIPTION
Issue 1 :  In case of U20 to U22 upgrade options are provided as below.

```
The Zimbra Collaboration Server appears to already be installed.
It can be upgraded with no effect on existing accounts,
or the current installation can be completely removed prior
to installation for a clean install.

Do you wish to upgrade? [Y]

Scanning for any new or additional packages available for installation
Existing packages will be upgraded
```

Expected output is

```
The Zimbra Collaboration Server does not appear to be installed,
yet there appears to be a ZCS directory structure in /opt/zimbra.

Would you like to delete /opt/zimbra before installing? [N]

Select the packages to install
```

Issue 2 : Onlyoffice not running after upgrade

```
onlyoffice     Stopped
onlyoffice - converter is running.
onlyoffice - docservice is not running.
rabbitmq is running.
```



