### PR TITLE
ZCS-15268: Usage correction mails are not getting sent to admin after usage correction.

### DIFF
--- a/rpmconf/Install/zmsetup.pl
+++ b/rpmconf/Install/zmsetup.pl
@@ -7379,6 +7379,12 @@ sub applyConfig {
     configImap();
   }
 
+  if (getLdapConfigValue("zimbraLicenseNotificationEmail") eq "") {
+          progress("Setting zimbraLicenseNotificationEmail...");
+          setLdapGlobalConfig("zimbraLicenseNotificationEmail", $config{CREATEADMIN});
+          progress("done.\n");
+  }
+
   configureOnlyoffice();
 
   if ($config{STARTSERVERS} eq "yes") {


### PR DESCRIPTION
Updated the zmsetup.pl so that ZimbraLicenseNotificationEmail is set to admin account by default and usage correction notification mails are sent to admin by default.