### PR TITLE
ZBUG-4023:Upgraded jetty to 9.4.57.v20241219

### DIFF
--- a/rpmconf/Spec/zimbra-store.deb
+++ b/rpmconf/Spec/zimbra-store.deb
@@ -5,4 +5,4 @@ Maintainer: build@zimbra.com
 Section: Mail
 Priority: optional
 Architecture: @@ARCH@@
-Depends: zimbra-core, zimbra-store-components, zimbra-jetty-distribution (>= 9.4.46.v20220331-2.@@PKG_OS_TAG@@)@@MORE_DEPENDS@@
+Depends: zimbra-core, zimbra-store-components, zimbra-jetty-distribution (>= 9.4.57.v20241219-2.@@PKG_OS_TAG@@)@@MORE_DEPENDS@@

--- a/rpmconf/Spec/zimbra-store.spec
+++ b/rpmconf/Spec/zimbra-store.spec
@@ -12,7 +12,7 @@ Vendor: Zimbra, Inc.
 Packager: Zimbra, Inc.
 BuildRoot: /opt/zimbra
 AutoReqProv: no
-requires: zimbra-core, zimbra-store-components, zimbra-jetty-distribution >= 9.4.46.v20220331-2.@@PKG_OS_TAG@@@@MORE_DEPENDS@@
+requires: zimbra-core, zimbra-store-components, zimbra-jetty-distribution >= 9.4.57.v20241219-2.@@PKG_OS_TAG@@@@MORE_DEPENDS@@
 
 %description
 Best email money can buy


### PR DESCRIPTION
zimbra-jetty-distribution Upgraded to version 9.4.57.v20241219

Related PR's:-
[Zimbra/zm-zcs-lib/pull/115]
[Zimbra/zm-jetty-conf/pull/26]
[Zimbra/zm-mailbox/pull/1706]
[Zimbra/zm-web-client/pull/886]
[Zimbra/zm-admin-console/pull/182]