### PR TITLE
ZBUG-4617 - Modified installer script to check prerequisite.

### DIFF
--- a/rpmconf/Install/install.sh
+++ b/rpmconf/Install/install.sh
@@ -28,6 +28,18 @@ if [ ! -x "/usr/bin/perl" ]; then
   exit 1
 fi
 
+# Function to check for rsyslog or syslog-ng package
+check_logging_prerequisites() {
+  if command -v rsyslogd >/dev/null 2>&1 || command -v syslog-ng >/dev/null 2>&1; then
+    return 0
+  else
+    echo "Zimbra installation requires rsyslog or syslog-ng package to be installed."
+    exit 1
+  fi
+}
+# Perform logging prerequisite check
+check_logging_prerequisites
+
 MYDIR="$(cd "$(dirname "$0")" && pwd)"
 
 . ./util/utilfunc.sh

--- a/rpmconf/Install/install.sh
+++ b/rpmconf/Install/install.sh
@@ -83,6 +83,16 @@ checkSkipActivation() {
 	fi
 }
 
+# Function to check for rsyslog or syslog-ng package
+check_logging_prerequisites() {
+  if command -v rsyslogd >/dev/null 2>&1 || command -v syslog-ng >/dev/null 2>&1; then
+    return 0
+  else
+    echo "Zimbra installation requires rsyslog or syslog-ng package to be installed."
+    exit 1
+  fi
+}
+
 
 while [ $# -ne 0 ]; do
   case $1 in
@@ -192,6 +202,9 @@ fi
 displayLicense
 
 checkUser root
+
+# prerequisite check
+check_logging_prerequisites
 
 if [ $AUTOINSTALL = "yes" ]; then
 	loadConfig $DEFAULTFILE


### PR DESCRIPTION
zimbra-installer script get modified to check prerequisite for **rsyslog**  or **syslog-ng** package.
if non of above package is installed before installation then zimbra-installation gets stopped  