### PR TITLE
ZBUG-4617 - Modified installer script to check prerequisite

### DIFF
--- a/rpmconf/Install/install.sh
+++ b/rpmconf/Install/install.sh
@@ -28,6 +28,19 @@ if [ ! -x "/usr/bin/perl" ]; then
   exit 1
 fi
 
+# Function to check for rsyslog or syslog-ng package
+is_rsyslog_or_syslog-ng_present(){
+  if command -v rsyslogd >/dev/null 2>&1 || command -v syslog-ng >/dev/null 2>&1; then
+    return 0
+  else
+    echo "Zimbra installation requires rsyslog or syslog-ng package to be installed."
+    exit 1
+  fi
+}
+
+# Perform logging prerequisite check
+is_rsyslog_or_syslog-ng_present
+
 MYDIR="$(cd "$(dirname "$0")" && pwd)"
 
 . ./util/utilfunc.sh


### PR DESCRIPTION
zimbra-installer script get modified to check prerequisite for **rsyslog** or **syslog-ng** package.
if none of above package is installed before installation then zimbra-installation gets stopped

