### PR TITLE
ZCS-17150 : added utility to fetch all domains with Chat enabled

### DIFF
--- a/instructions/bundling-scripts/zimbra-core.sh
+++ b/instructions/bundling-scripts/zimbra-core.sh
@@ -304,6 +304,7 @@ main()
    Copy ${repoDir}/zm-core-utils/src/bin/zmonlyofficeinstall                                        ${repoDir}/zm-build/${currentPackage}/opt/zimbra/bin/zmonlyofficeinstall
    Copy ${repoDir}/zm-core-utils/src/bin/zmlicensectl                                               ${repoDir}/zm-build/${currentPackage}/opt/zimbra/bin/zmlicensectl
    Copy ${repoDir}/zm-core-utils/src/bin/zmacl                                                      ${repoDir}/zm-build/${currentPackage}/opt/zimbra/bin/zmacl
+   Copy ${repoDir}/zm-core-utils/src/bin/zmchatprovall                                              ${repoDir}/zm-build/${currentPackage}/opt/zimbra/bin/zmchatprovall
    Copy ${repoDir}/zm-core-utils/src/contrib/zmfetchercfg                                           ${repoDir}/zm-build/${currentPackage}/opt/zimbra/contrib/zmfetchercfg
    Copy ${repoDir}/zm-core-utils/src/libexec/600.zimbra                                             ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/600.zimbra
    Copy ${repoDir}/zm-core-utils/src/libexec/client_usage_report.py                                 ${repoDir}/zm-build/${currentPackage}/opt/zimbra/libexec/client_usage_report.py


### PR DESCRIPTION
Problem: There was no API available to provision all domains at once, which led to manual provisioning for each domain.
Fix: Logic: A script has been created to provision all domains simultaneously, streamlining the process and reducing manual effort.
Steps to test:

1. Run the zmchatprovall command.
2. Verify that all accounts are successfully provisioned and can use the chat feature.