### PR TITLE
Revert "ZBUG-4023:Upgraded jetty to 9.4.57.v20241219"

### DIFF
--- a/rpmconf/Spec/zimbra-store.deb
+++ b/rpmconf/Spec/zimbra-store.deb
@@ -5,4 +5,4 @@ Maintainer: build@zimbra.com
 Section: Mail
 Priority: optional
 Architecture: @@ARCH@@
-Depends: zimbra-core, zimbra-store-components, zimbra-jetty-distribution (>= 9.4.57.v20241219-2.@@PKG_OS_TAG@@)@@MORE_DEPENDS@@
+Depends: zimbra-core, zimbra-store-components, zimbra-jetty-distribution (>= 9.4.46.v20220331-2.@@PKG_OS_TAG@@)@@MORE_DEPENDS@@

--- a/rpmconf/Spec/zimbra-store.spec
+++ b/rpmconf/Spec/zimbra-store.spec
@@ -12,7 +12,7 @@ Vendor: Zimbra, Inc.
 Packager: Zimbra, Inc.
 BuildRoot: /opt/zimbra
 AutoReqProv: no
-requires: zimbra-core, zimbra-store-components, zimbra-jetty-distribution >= 9.4.57.v20241219-2.@@PKG_OS_TAG@@@@MORE_DEPENDS@@
+requires: zimbra-core, zimbra-store-components, zimbra-jetty-distribution >= 9.4.46.v20220331-2.@@PKG_OS_TAG@@@@MORE_DEPENDS@@
 
 %description
 Best email money can buy


### PR DESCRIPTION
Reverts Zimbra/zm-build#301

Reverting Above changes for now because, **zimbra-jetty-distribution package** involves changes in another zimbra-repositories also (zm-build, zm-zcs-lib, zm-mailbox, zm-jetty-conf)
merging this changes will result into **failure/installation of dev-builds because new Jetty-distribution is package not present in package repository.**
will raise New-PR for this changes while upcoming patch release..