### PR TITLE
 ZCS-18299:implementation & Enhancement for Code-coverage in zimbra-unit-tests pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Build from develop branch
     git clone https://github.com/Zimbra/zm-build.git
     cd zm-build
     git checkout origin/develop
-	ENV_CACHE_CLEAR_FLAG=true ./build.pl --ant-options -DskipTests=true --ant-options -DskipCoverage=true --git-default-branch=develop --build-release-no=10.1.0 --build-         type=FOSS --build-release=LIBERTY --build-release-candidate=GA --build-thirdparty-server=files.zimbra.com --no-interactive
+	ENV_CACHE_CLEAR_FLAG=true ./build.pl --ant-options -DskipTests=true --ant-options -DskipCoverage=true --git-default-branch=develop --build-release-no=10.1.0 --build-type=FOSS --build-release=LIBERTY --build-release-candidate=GA --build-thirdparty-server=files.zimbra.com --no-interactive
 
 Build 10.1.0
 

--- a/README.md
+++ b/README.md
@@ -78,12 +78,14 @@ logged in as a non-root user with `sudo` privileges.
 
 ## Building
 Create a directory for your build and check-out the `zm-build` repository:
+Build from develop branch
 
     mkdir installer-build
     cd installer-build
     git clone https://github.com/Zimbra/zm-build.git
     cd zm-build
     git checkout origin/develop
+	ENV_CACHE_CLEAR_FLAG=true ./build.pl --ant-options -DskipTests=true --ant-options -DskipCoverage=true --git-default-branch=develop --build-release-no=10.1.0 --build-         type=FOSS --build-release=LIBERTY --build-release-candidate=GA --build-thirdparty-server=files.zimbra.com --no-interactive
 
 Build 10.1.0
 

--- a/build.pl
+++ b/build.pl
@@ -508,7 +508,7 @@ sub Build($)
       ],
    };
 
-   push( @{ $tool_attributes->{ant} }, $CFG{ANT_OPTIONS} )
+   push( @{ $tool_attributes->{ant} }, split(/\s+/, $CFG{ANT_OPTIONS}) )
      if ( $CFG{ANT_OPTIONS} );
 
    push( @{ $tool_attributes->{mvn} }, $CFG{MVN_OPTIONS} )
@@ -555,15 +555,8 @@ sub Build($)
                      {
                         if ( my $targets = $build_info->{ $tool . "_targets" } )    #Known values are: ant_targets, mvn_targets, make_targets
                         {
-                           if ($tool eq 'ant' && $CFG{ANT_OPTIONS}) {
-                               my $opts = $CFG{ANT_OPTIONS};
-                               if ($opts =~ /-DskipCoverage=true/) {
-                                   @$targets = grep { $_ ne 'coverage' } @$targets;
-                                   print "Skipping coverage target due to -DskipCoverage=true\n";
-                               }
-                           }
                            eval { SysExec( $tool, "clean" ) if ( !$ENV{ENV_SKIP_CLEAN_FLAG} ); };
-                           
+
                            SysExec( $tool, @{ $tool_attributes->{$tool} || [] }, @$targets );
                         }
                      }

--- a/build.pl
+++ b/build.pl
@@ -565,7 +565,7 @@ sub Build($)
                            }
                            eval { SysExec( $tool, "clean" ) if ( !$ENV{ENV_SKIP_CLEAN_FLAG} ); };
                            
-                           SysExec( $tool, @{ $tool_attributes->{$tool} || [] }, @filtered_targets );
+                           SysExec( $tool, @{ $tool_attributes->{$tool} || [] }, @$targets );
                         }
                      }
                   }

--- a/build.pl
+++ b/build.pl
@@ -99,8 +99,14 @@ sub LoadConfiguration($)
       else
       {
          $CFG{$cfg_name} = $val;
-
-         printf( " %-35s: %-17s : %s\n", $cfg_name, $cmd_hash ? $src : "detected", $val );
+         if (ref($val) eq 'ARRAY')
+         {
+            printf( " %-35s: %-17s : %s\n", $cfg_name, $cmd_hash ? $src : "detected", join(' ', @$val) );
+         }
+         else
+         {
+            printf( " %-35s: %-17s : %s\n", $cfg_name, $cmd_hash ? $src : "detected", $val );
+         }
       }
    }
 }
@@ -142,7 +148,7 @@ sub InitGlobalBuildVars()
          { name => "GIT_DEFAULT_BRANCH",         type => "=s",  hash_src => \%cmd_hash, default_sub => sub { return undef; }, },
          { name => "GIT_DEFAULT_REPO_NAME_SUFFIX", type => "=s",  hash_src => \%cmd_hash, default_sub => sub { return undef; }, },
          { name => "STOP_AFTER_CHECKOUT",        type => "!",   hash_src => \%cmd_hash, default_sub => sub { return 0; }, },
-         { name => "ANT_OPTIONS",                type => "=s",  hash_src => \%cmd_hash, default_sub => sub { return undef; }, },
+         { name => "ANT_OPTIONS",                type => "=s@",  hash_src => \%cmd_hash, default_sub => sub { return undef; }, },
          { name => "MVN_OPTIONS",                type => "=s",  hash_src => \%cmd_hash, default_sub => sub { return undef; }, },
          { name => "BUILD_HOSTNAME",             type => "=s",  hash_src => \%cmd_hash, default_sub => sub { return Net::Domain::hostfqdn; }, },
          { name => "BUILD_ARCH",                 type => "=s",  hash_src => \%cmd_hash, default_sub => sub { return GetBuildArch(); }, },
@@ -167,13 +173,17 @@ sub InitGlobalBuildVars()
             print "   --" . "$_->{opt}$_->{opt_s}\n" foreach (@cmd_opts);
             exit(0);
          };
-
+         Getopt::Long::Configure("pass_through");
          if ( !GetOptions( \%cmd_hash, ( map { $_->{opt} . $_->{opt_s} } @cmd_opts ), help => $help_func ) )
          {
             print Die("wrong commandline options, use --help");
          }
       }
-
+      if ( $cmd_hash{'ant-options'} ) {
+          foreach my $extra (@ARGV) {
+              push @{ $cmd_hash{'ant-options'} }, $extra if $extra =~ /^-D/;
+          }
+      }
       print "=========================================================================================================\n";
       LoadConfiguration($_) foreach (@cmd_args);
       print "=========================================================================================================\n";
@@ -508,7 +518,7 @@ sub Build($)
       ],
    };
 
-   push( @{ $tool_attributes->{ant} }, split(/\s+/, $CFG{ANT_OPTIONS}) )
+   push( @{ $tool_attributes->{ant} }, @{ $CFG{ANT_OPTIONS} } )
      if ( $CFG{ANT_OPTIONS} );
 
    push( @{ $tool_attributes->{mvn} }, $CFG{MVN_OPTIONS} )

--- a/build.pl
+++ b/build.pl
@@ -144,7 +144,6 @@ sub InitGlobalBuildVars()
          { name => "STOP_AFTER_CHECKOUT",        type => "!",   hash_src => \%cmd_hash, default_sub => sub { return 0; }, },
          { name => "ANT_OPTIONS",                type => "=s",  hash_src => \%cmd_hash, default_sub => sub { return undef; }, },
          { name => "MVN_OPTIONS",                type => "=s",  hash_src => \%cmd_hash, default_sub => sub { return undef; }, },
-         { name => "NO_COVERAGE",                type => "!",   hash_src => \%cmd_hash, default_sub => sub { return 0; }, },
          { name => "BUILD_HOSTNAME",             type => "=s",  hash_src => \%cmd_hash, default_sub => sub { return Net::Domain::hostfqdn; }, },
          { name => "BUILD_ARCH",                 type => "=s",  hash_src => \%cmd_hash, default_sub => sub { return GetBuildArch(); }, },
          { name => "PKG_OS_TAG",                 type => "=s",  hash_src => \%cmd_hash, default_sub => sub { return GetPkgOsTag(); }, },

--- a/build.pl
+++ b/build.pl
@@ -173,16 +173,10 @@ sub InitGlobalBuildVars()
             print "   --" . "$_->{opt}$_->{opt_s}\n" foreach (@cmd_opts);
             exit(0);
          };
-         Getopt::Long::Configure("pass_through");
          if ( !GetOptions( \%cmd_hash, ( map { $_->{opt} . $_->{opt_s} } @cmd_opts ), help => $help_func ) )
          {
             print Die("wrong commandline options, use --help");
          }
-      }
-      if ( $cmd_hash{'ant-options'} ) {
-          foreach my $extra (@ARGV) {
-              push @{ $cmd_hash{'ant-options'} }, $extra if $extra =~ /^-D/;
-          }
       }
       print "=========================================================================================================\n";
       LoadConfiguration($_) foreach (@cmd_args);
@@ -518,11 +512,12 @@ sub Build($)
       ],
    };
 
-   push( @{ $tool_attributes->{ant} }, @{ $CFG{ANT_OPTIONS} } )
-     if ( $CFG{ANT_OPTIONS} );
-
+   push @{ $tool_attributes->{ant} },
+       ref $CFG{ANT_OPTIONS} eq 'ARRAY' ? @{ $CFG{ANT_OPTIONS} } : ($CFG{ANT_OPTIONS})
+       if defined $CFG{ANT_OPTIONS};
+     
    push( @{ $tool_attributes->{mvn} }, $CFG{MVN_OPTIONS} )
-     if ( $CFG{MVN_OPTIONS} );
+       if ( $CFG{MVN_OPTIONS} );
 
    my $cnt = 0;
    for my $build_info (@ALL_BUILDS)

--- a/build.pl
+++ b/build.pl
@@ -556,9 +556,12 @@ sub Build($)
                      {
                         if ( my $targets = $build_info->{ $tool . "_targets" } )    #Known values are: ant_targets, mvn_targets, make_targets
                         {
-                           my @filtered_targets = @$targets;
-                           if ($tool eq 'ant' && $CFG{NO_COVERAGE}) {
-                              @filtered_targets = grep { $_ ne 'coverage' } @filtered_targets;
+                           if ($tool eq 'ant' && $CFG{ANT_OPTIONS}) {
+                               my $opts = $CFG{ANT_OPTIONS};
+                               if ($opts =~ /-DskipCoverage=true/) {
+                                   @$targets = grep { $_ ne 'coverage' } @$targets;
+                                   print "Skipping coverage target due to -DskipCoverage=true\n";
+                               }
                            }
                            eval { SysExec( $tool, "clean" ) if ( !$ENV{ENV_SKIP_CLEAN_FLAG} ); };
                            

--- a/build.pl
+++ b/build.pl
@@ -144,6 +144,7 @@ sub InitGlobalBuildVars()
          { name => "STOP_AFTER_CHECKOUT",        type => "!",   hash_src => \%cmd_hash, default_sub => sub { return 0; }, },
          { name => "ANT_OPTIONS",                type => "=s",  hash_src => \%cmd_hash, default_sub => sub { return undef; }, },
          { name => "MVN_OPTIONS",                type => "=s",  hash_src => \%cmd_hash, default_sub => sub { return undef; }, },
+         { name => "NO_COVERAGE",                type => "!",   hash_src => \%cmd_hash, default_sub => sub { return 0; }, },
          { name => "BUILD_HOSTNAME",             type => "=s",  hash_src => \%cmd_hash, default_sub => sub { return Net::Domain::hostfqdn; }, },
          { name => "BUILD_ARCH",                 type => "=s",  hash_src => \%cmd_hash, default_sub => sub { return GetBuildArch(); }, },
          { name => "PKG_OS_TAG",                 type => "=s",  hash_src => \%cmd_hash, default_sub => sub { return GetPkgOsTag(); }, },
@@ -555,9 +556,13 @@ sub Build($)
                      {
                         if ( my $targets = $build_info->{ $tool . "_targets" } )    #Known values are: ant_targets, mvn_targets, make_targets
                         {
+                           my @filtered_targets = @$targets;
+                           if ($tool eq 'ant' && $CFG{NO_COVERAGE}) {
+                              @filtered_targets = grep { $_ ne 'coverage' } @filtered_targets;
+                           }
                            eval { SysExec( $tool, "clean" ) if ( !$ENV{ENV_SKIP_CLEAN_FLAG} ); };
-
-                           SysExec( $tool, @{ $tool_attributes->{$tool} || [] }, @$targets );
+                           
+                           SysExec( $tool, @{ $tool_attributes->{$tool} || [] }, @filtered_targets );
                         }
                      }
                   }

--- a/instructions/FOSS_staging_list.pl
+++ b/instructions/FOSS_staging_list.pl
@@ -66,7 +66,7 @@
    },
    {
       "dir"         => "zm-ssdb-ephemeral-store",
-      "ant_targets" => ["publish-local", "test"],
+      "ant_targets" => ["publish-local", "test", "coverage"],
       "stage_cmd"   => sub {
          SysExec("mkdir -p $CFG{BUILD_DIR}/zm-ssdb-ephemeral-store/build/dist");
          SysExec("cp -f build/zm-ssdb-ephemeral-store*.jar $CFG{BUILD_DIR}/zm-ssdb-ephemeral-store/build/dist");
@@ -74,7 +74,7 @@
    },
    {
       "dir"         => "zm-openid-consumer-store",
-      "ant_targets" => ["dist-package", "test"],
+      "ant_targets" => ["dist-package", "test", "coverage"],
       "stage_cmd"   => sub {
          SysExec("mkdir -p $CFG{BUILD_DIR}/zm-openid-consumer-store/build/dist");
          SysExec("cp -f -r build/dist $CFG{BUILD_DIR}/zm-openid-consumer-store/build/");
@@ -82,7 +82,7 @@
    },
    {
       "dir"         => "zm-clam-scanner-store",
-      "ant_targets" => ["publish-local", "test"],
+      "ant_targets" => ["publish-local", "test", "coverage"],
       "stage_cmd"   => sub {
          SysExec("mkdir -p $CFG{BUILD_DIR}/zm-clam-scanner-store/build/dist");
          SysExec("cp -f -rp build/zm-clam-scanner-store-*.jar $CFG{BUILD_DIR}/zm-clam-scanner-store/build/dist");
@@ -98,7 +98,7 @@
    },
    {
       "dir"         => "zm-nginx-lookup-store",
-      "ant_targets" => ["publish-local", "test"],
+      "ant_targets" => ["publish-local", "test", "coverage"],
       "stage_cmd"   => sub {
          SysExec("mkdir -p $CFG{BUILD_DIR}/zm-nginx-lookup-store/build/dist");
          SysExec("cp -f -rp build/zm-nginx-lookup-store-*.jar $CFG{BUILD_DIR}/zm-nginx-lookup-store/build/dist");
@@ -369,7 +369,7 @@
    
    {
       "dir"         => "zm-oauth-social",
-      "ant_targets" => ["publish-local", "oauth-social-common-jar", "oauth-social-jar", "test"],
+      "ant_targets" => ["publish-local", "oauth-social-common-jar", "oauth-social-jar", "test", "coverage"],
       "stage_cmd"   => sub {
          SysExec("mkdir -p $CFG{BUILD_DIR}/zm-oauth-social/build/dist");
          SysExec("cp -f -rp build/zm-oauth-social*.jar $CFG{BUILD_DIR}/zm-oauth-social/build/dist");
@@ -378,7 +378,7 @@
    
    {
       "dir"         => "zm-gql",
-      "ant_targets" => ["publish-local", "test"],
+      "ant_targets" => ["publish-local", "test", "coverage"],
       "stage_cmd"   => sub {
          SysExec("mkdir -p $CFG{BUILD_DIR}/zm-gql/build/dist");
          SysExec("cp -f -rp build/zm-gql-*.jar $CFG{BUILD_DIR}/zm-gql/build/dist");

--- a/instructions/FOSS_staging_list.pl
+++ b/instructions/FOSS_staging_list.pl
@@ -11,7 +11,7 @@
    },
    {
       "dir"         => "zm-mailbox/store",
-      "ant_targets" => ["publish-store-test", "test"],
+      "ant_targets" => ["publish-store-test", "test", "coverage"],
       "stage_cmd"   => undef,
    },
    {


### PR DESCRIPTION
-> Added new ant_targets=coverage for code-coverage
Changes in build.pl ->
->Added support for passing multiple --ant-options arguments to build.pl without quotation.
->ANT_OPTIONS values are now collected into an array and injected into the Ant build command.
input ->
` ENV_CACHE_CLEAR_FLAG=true ./build.pl --ant-options -DskipTests=true --ant-options -DskipCoverage=true --git-default-tag=10.1.0 --build-release-no=10.1.0 --build-type=FOSS --build-release=LIBERTY --build-release-candidate=GA --build-thirdparty-server=files.zimbra.com --no-interactive`

Result ->
` ANT_OPTIONS                        : cmdline           : -DskipTests=true -DskipCoverage=true`